### PR TITLE
Remove # pylint: skip-file usage

### DIFF
--- a/plugins/action/vyos.py
+++ b/plugins/action/vyos.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/cliconf/vyos.py
+++ b/plugins/cliconf/vyos.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/plugins/module_utils/network/vyos/argspec/facts/facts.py
+++ b/plugins/module_utils/network/vyos/argspec/facts/facts.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The arg spec for the vyos facts module.
 """

--- a/plugins/module_utils/network/vyos/argspec/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_global/firewall_global.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/firewall_interfaces/firewall_interfaces.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_interfaces/firewall_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/interfaces/interfaces.py
+++ b/plugins/module_utils/network/vyos/argspec/interfaces/interfaces.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/vyos/argspec/l3_interfaces/l3_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/vyos/argspec/lag_interfaces/lag_interfaces.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/vyos/argspec/lldp_global/lldp_global.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/vyos/argspec/lldp_interfaces/lldp_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/argspec/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/vyos/argspec/ospfv2/ospfv2.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/module_utils/network/vyos/argspec/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/vyos/argspec/ospfv3/ospfv3.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/module_utils/network/vyos/argspec/static_routes/static_routes.py
+++ b/plugins/module_utils/network/vyos/argspec/static_routes/static_routes.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_firewall_global class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/firewall_interfaces/firewall_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/firewall_interfaces/firewall_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_firewall_interfaces class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_firewall_rules class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/interfaces/interfaces.py
+++ b/plugins/module_utils/network/vyos/config/interfaces/interfaces.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_interfaces class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/l3_interfaces/l3_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_l3_interfaces class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_lag_interfaces class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/vyos/config/lldp_global/lldp_global.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_lldp_global class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/lldp_interfaces/lldp_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_lldp_interfaces class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/vyos/config/ospfv2/ospfv2.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_ospfv2 class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/vyos/config/ospfv3/ospfv3.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_ospfv3 class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/vyos/config/static_routes/static_routes.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos_static_routes class
 It is in this file where the current configuration (as dict)

--- a/plugins/module_utils/network/vyos/facts/facts.py
+++ b/plugins/module_utils/network/vyos/facts/facts.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The facts class for vyos
 this file validates each subset of facts and selectively

--- a/plugins/module_utils/network/vyos/facts/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/facts/firewall_global/firewall_global.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos firewall_global fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/firewall_interfaces/firewall_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/firewall_interfaces/firewall_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos firewall_interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/facts/firewall_rules/firewall_rules.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos firewall_rules fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/interfaces/interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/interfaces/interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/l3_interfaces/l3_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos l3_interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/lag_interfaces/lag_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos lag_interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/legacy/base.py
+++ b/plugins/module_utils/network/vyos/facts/legacy/base.py
@@ -2,7 +2,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The VyOS interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/vyos/facts/lldp_global/lldp_global.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos lldp_global fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/lldp_interfaces/lldp_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos lldp_interfaces fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/vyos/facts/ospfv2/ospfv2.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos ospfv2 fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/vyos/facts/ospfv3/ospfv3.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos ospfv3 fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/vyos/facts/static_routes/static_routes.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The vyos static_routes fact class
 It is in this file the configuration is collected from the device

--- a/plugins/module_utils/network/vyos/utils/utils.py
+++ b/plugins/module_utils/network/vyos/utils/utils.py
@@ -2,7 +2,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 # utils
 from __future__ import absolute_import, division, print_function

--- a/plugins/module_utils/network/vyos/vyos.py
+++ b/plugins/module_utils/network/vyos/vyos.py
@@ -25,7 +25,6 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# pylint: skip-file
 import json
 
 from ansible.module_utils._text import to_text

--- a/plugins/modules/vyos_banner.py
+++ b/plugins/modules/vyos_banner.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """

--- a/plugins/modules/vyos_command.py
+++ b/plugins/modules/vyos_command.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """
@@ -189,7 +188,7 @@ def main():
     interval = module.params["interval"]
     match = module.params["match"]
 
-    for _ in range(retries):
+    for item in range(retries):
         responses = run_commands(module, commands)
 
         for item in list(conditionals):

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """

--- a/plugins/modules/vyos_facts.py
+++ b/plugins/modules/vyos_facts.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 """
 The module file for vyos_facts
 """

--- a/plugins/modules/vyos_firewall_global.py
+++ b/plugins/modules/vyos_firewall_global.py
@@ -21,7 +21,6 @@
 #   builder template.
 #
 #############################################
-# pylint: skip-file
 
 """
 The module file for vyos_firewall_global

--- a/plugins/modules/vyos_firewall_interfaces.py
+++ b/plugins/modules/vyos_firewall_interfaces.py
@@ -21,7 +21,6 @@
 #   builder template.
 #
 #############################################
-# pylint: skip-file
 
 """
 The module file for vyos_firewall_interfaces

--- a/plugins/modules/vyos_firewall_rules.py
+++ b/plugins/modules/vyos_firewall_rules.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_interface.py
+++ b/plugins/modules/vyos_interface.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_interfaces.py
+++ b/plugins/modules/vyos_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_l3_interface.py
+++ b/plugins/modules/vyos_l3_interface.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_l3_interfaces.py
+++ b/plugins/modules/vyos_l3_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_lag_interfaces.py
+++ b/plugins/modules/vyos_lag_interfaces.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_linkagg.py
+++ b/plugins/modules/vyos_linkagg.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_lldp.py
+++ b/plugins/modules/vyos_lldp.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_lldp_global.py
+++ b/plugins/modules/vyos_lldp_global.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_lldp_interface.py
+++ b/plugins/modules/vyos_lldp_interface.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_lldp_interfaces.py
+++ b/plugins/modules/vyos_lldp_interfaces.py
@@ -21,7 +21,6 @@
 #   builder template.
 #
 #############################################
-# pylint: skip-file
 
 """
 The module file for vyos_lldp_interfaces

--- a/plugins/modules/vyos_logging.py
+++ b/plugins/modules/vyos_logging.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """

--- a/plugins/modules/vyos_ospfv2.py
+++ b/plugins/modules/vyos_ospfv2.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_ospfv3.py
+++ b/plugins/modules/vyos_ospfv3.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_ping.py
+++ b/plugins/modules/vyos_ping.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_static_route.py
+++ b/plugins/modules/vyos_static_route.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/modules/vyos_static_routes.py
+++ b/plugins/modules/vyos_static_routes.py
@@ -3,7 +3,6 @@
 # Copyright 2019 Red Hat
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 #############################################
 #                WARNING                    #

--- a/plugins/modules/vyos_system.py
+++ b/plugins/modules/vyos_system.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 
 
 DOCUMENTATION = """

--- a/plugins/modules/vyos_vlan.py
+++ b/plugins/modules/vyos_vlan.py
@@ -3,7 +3,6 @@
 
 # Copyright: (c) 2017, Ansible by Red Hat, inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# pylint: skip-file
 
 from __future__ import absolute_import, division, print_function
 

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/compat/unittest.py
+++ b/tests/unit/compat/unittest.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_banner.py
+++ b/tests/unit/modules/network/vyos/test_vyos_banner.py
@@ -14,7 +14,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_command.py
+++ b/tests/unit/modules/network/vyos/test_vyos_command.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_config.py
+++ b/tests/unit/modules/network/vyos/test_vyos_config.py
@@ -17,7 +17,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_facts.py
+++ b/tests/unit/modules/network/vyos/test_vyos_facts.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_interfaces.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_interfaces.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_ospfv2.py
+++ b/tests/unit/modules/network/vyos/test_vyos_ospfv2.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_ospfv3.py
+++ b/tests/unit/modules/network/vyos/test_vyos_ospfv3.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_ping.py
+++ b/tests/unit/modules/network/vyos/test_vyos_ping.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_static_route.py
+++ b/tests/unit/modules/network/vyos/test_vyos_static_route.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_static_routes.py
+++ b/tests/unit/modules/network/vyos/test_vyos_static_routes.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_system.py
+++ b/tests/unit/modules/network/vyos/test_vyos_system.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type

--- a/tests/unit/modules/network/vyos/vyos_module.py
+++ b/tests/unit/modules/network/vyos/vyos_module.py
@@ -16,7 +16,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-# pylint: skip-file
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type


### PR DESCRIPTION
This is no longer needed as ansible-test sanity have been updated to
ignore duplicate-code errors.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>