### PR TITLE
Prevent vyos_config from saving in check mode.

### DIFF
--- a/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vyos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/vyos.vyos/pull/53)

--- a/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vyos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/vyos.vyos/pull/53)

--- a/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
+++ b/changelogs/fragements/prevent-vyos_config-saving-in-check-mode.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - vyos_config - fixed issue where config could be saved while in check mode (https://github.com/ansible-collections/vyos.vyos/pull/53)

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -339,7 +339,8 @@ def main():
     if module.params["save"]:
         diff = run_commands(module, commands=["configure", "compare saved"])[1]
         if diff != "[edit]":
-            run_commands(module, commands=["save"])
+            if not module.check_mode:
+                run_commands(module, commands=["save"])
             result["changed"] = True
         run_commands(module, commands=["exit"])
 

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -339,8 +339,7 @@ def main():
     if module.params["save"]:
         diff = run_commands(module, commands=["configure", "compare saved"])[1]
         if diff != "[edit]":
-            if not module.check_mode:
-                run_commands(module, commands=["save"])
+            run_commands(module, commands=["save"])
             result["changed"] = True
         run_commands(module, commands=["exit"])
 


### PR DESCRIPTION
##### SUMMARY
This PR prevents configuration from being saved while running in check mode. This aligns vyos_config's behaviour with other _config modules and with the intention of Ansible's check mode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vyos_config

##### ADDITIONAL INFORMATION
Examples of other _command modules which avoid saving in check mode. 
https://github.com/ansible-collections/arista.eos/blob/master/plugins/modules/eos_config.py
https://github.com/ansible-collections/cisco.asa/blob/master/plugins/modules/asa_config.py
https://github.com/ansible-collections/cisco.ios/blob/master/plugins/modules/ios_config.py