### PR TITLE
Make config modules work properly when module alias is used in task

### DIFF
--- a/changelogs/fragments/fix_src_backup_with_module_alias.yaml
+++ b/changelogs/fragments/fix_src_backup_with_module_alias.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Make `src`, `backup` and `backup_options` in vyos_config work when module alias is used (https://github.com/ansible-collections/vyos.vyos/pull/67).

--- a/plugins/action/vyos.py
+++ b/plugins/action/vyos.py
@@ -42,7 +42,9 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         module_name = self._task.action.split(".")[-1]
-        self._config_module = True if module_name == "vyos_config" else False
+        self._config_module = (
+            True if module_name in ["vyos_config", "config"] else False
+        )
         persistent_connection = self._play_context.connection.split(".")[-1]
         warnings = []
 

--- a/tests/integration/targets/vyos_config/templates/config.j2
+++ b/tests/integration/targets/vyos_config/templates/config.j2
@@ -1,0 +1,2 @@
+set interfaces ethernet eth0 description TEST-INTF
+set system login user test_user

--- a/tests/integration/targets/vyos_config/tests/redirection/cli/shortname.yaml
+++ b/tests/integration/targets/vyos_config/tests/redirection/cli/shortname.yaml
@@ -56,7 +56,7 @@
 
 - name: Remove interface description and delete temp user
   vyos.vyos.config: &cleanup
-    lines: 
+    lines:
       - "delete interfaces ethernet eth0 description TEST-INTF"
       - "delete system login user test_user"
 

--- a/tests/integration/targets/vyos_config/tests/redirection/cli/shortname.yaml
+++ b/tests/integration/targets/vyos_config/tests/redirection/cli/shortname.yaml
@@ -54,4 +54,46 @@
     that:
       - '{{ result.filtered|length }} == 2'
 
+- name: Remove interface description and delete temp user
+  vyos.vyos.config: &cleanup
+    lines: 
+      - "delete interfaces ethernet eth0 description TEST-INTF"
+      - "delete system login user test_user"
+
+- name: Use src with module alias
+  register: result
+  vyos.vyos.config:
+    src: config.j2
+
+- assert:
+    that:
+      - result.changed == true
+      - '"set interfaces ethernet eth0 description TEST-INTF" in result.commands'
+      - '"set system login user test_user" in result.commands'
+
+- name: "Restore hostname to {{ inventory_hostname }} and delete temp user"
+  vyos.vyos.config: *cleanup
+
+- name: use module alias to take configuration backup
+  register: result
+  vyos.vyos.config:
+    backup: true
+    backup_options:
+      filename: backup_with_alias.cfg
+      dir_path: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}'
+
+- assert:
+    that:
+      - result.changed == true
+
+- name: check if the backup file-4 exist
+  find:
+    paths: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup_with_alias.cfg'
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - backup_file.files is defined
+
 - debug: msg="END cli/shortname.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Module name will not always be prefixed with {{ network_os }}_.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
action/vyos.py
vyos_config.py
