### PR TITLE
Removed unwanted characters from gathered l3_int facts

### DIFF
--- a/changelogs/fragments/66-remove-unwanted-chars-l3int.yaml
+++ b/changelogs/fragments/66-remove-unwanted-chars-l3int.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added a function in netcommon to remove unwanted characters from gathered facts. issue seen in vyos latest sw.

--- a/plugins/module_utils/network/vyos/facts/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/l3_interfaces/l3_interfaces.py
@@ -20,6 +20,9 @@ from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
     utils,
 )
+from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
+    remove_unwanted_characters,
+)
 from ansible.module_utils.six import iteritems
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.utils import (
     get_ip_address_version,
@@ -95,6 +98,7 @@ class L3_interfacesFacts(object):
         :rtype: dictionary
         :returns: The generated config
         """
+        conf = remove_unwanted_characters(conf)
         vif_conf = "\n".join(filter(lambda x: ("vif" in x), conf))
         eth_conf = "\n".join(filter(lambda x: ("vif" not in x), conf))
         config = self.parse_attribs(eth_conf)


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/92

Fixes: https://github.com/ansible-collections/vyos.vyos/issues/66

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
facts/l3_interfaces/l3_interfaces.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
