### PR TITLE
Remove ansi codes from terminal output

### DIFF
--- a/changelogs/fragments/65-remove-unwanted-terminal-chars.yaml
+++ b/changelogs/fragments/65-remove-unwanted-terminal-chars.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Added characters to be removed from terminal output.
+  - terminal plugin - Added additional escape sequence to be removed from terminal output.

--- a/changelogs/fragments/65-remove-unwanted-terminal-chars.yaml
+++ b/changelogs/fragments/65-remove-unwanted-terminal-chars.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added characters to be removed from terminal output.

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -40,6 +40,12 @@ class TerminalModule(TerminalBase):
         re.compile(br"\n\s+Set failed"),
     ]
 
+    ansi_re = [
+        re.compile(br'\x1b\[\?1h\x1b='),  # CSI ? 1 h ESC =
+        re.compile(br'\x08.'),            # [Backspace] .
+        re.compile(br"\x1b\[m"),          # ANSI reset code
+    ]
+
     try:
         terminal_length = os.getenv("ANSIBLE_VYOS_TERMINAL_LENGTH", 10000)
         terminal_length = int(terminal_length)

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -41,9 +41,9 @@ class TerminalModule(TerminalBase):
     ]
 
     ansi_re = [
-        re.compile(br'\x1b\[\?1h\x1b='),  # CSI ? 1 h ESC =
-        re.compile(br'\x08.'),            # [Backspace] .
-        re.compile(br"\x1b\[m"),          # ANSI reset code
+        re.compile(br"\x1b\[\?1h\x1b="),  # CSI ? 1 h ESC =
+        re.compile(br"\x08."),  # [Backspace] .
+        re.compile(br"\x1b\[m"),  # ANSI reset code
     ]
 
     try:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Fixes : https://github.com/ansible-collections/vyos.vyos/issues/65    and    https://github.com/ansible-collections/vyos.vyos/issues/66

This can be removed once https://github.com/ansible/ansible/pull/70683 is available.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
plugins/terminal/vyos.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
