### PR TITLE
Avoid set_fact dynamically assigning value to a variable

### DIFF
--- a/changelogs/fragments/70-workaround-set_fact.yaml
+++ b/changelogs/fragments/70-workaround-set_fact.yaml
@@ -1,0 +1,3 @@
+---
+bug_fix:
+  - Added workaround to avoid set_fact dynamically assigning value. This behavior seems to have been broken after ansible2.9.

--- a/tests/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/tests/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -7,17 +7,19 @@
     commands:
       - show lldp neighbors detail
 
-- name: Should we run lldp tests?
-  set_fact:
-    run_lldp_tests: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
+
+# setting a variable dynamically using set_fact isn't working in devel.
+# - name: Should we run lldp tests?
+#  set_fact:
+#    run_lldp_tests: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Enable LLDP service
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   vyos.vyos.vyos_lldp:
     state: present
 
 - name: Create LLDP configuration
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   vyos.vyos.vyos_lldp_interface:
     name: eth1
     state: present
@@ -40,7 +42,7 @@
       - result.failed == false
 
 - name: Check lldp neighbors intent arguments
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   register: result
   vyos.vyos.vyos_interface:
     name: eth0
@@ -51,7 +53,7 @@
 - assert:
     that:
       - result.failed == false
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Check intent arguments (failed condition)
   ignore_errors: true
@@ -67,7 +69,7 @@
 
 - name: Check lldp neighbors intent arguments (failed)
   ignore_errors: true
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   register: result
   vyos.vyos.vyos_interface:
     name: eth0
@@ -81,7 +83,7 @@
       - result.failed == true
       - "'host dummy_host' in result.failed_conditions"
       - "'port dummy_port' in result.failed_conditions"
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Config + intent
   register: result
@@ -122,7 +124,7 @@
       - result.failed == false
 
 - name: Check lldp neighbors intent aggregate arguments
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   register: result
   vyos.vyos.vyos_interface:
     aggregate:
@@ -135,11 +137,11 @@
 - assert:
     that:
       - result.failed == false
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
 
 - name: Check lldp neighbors intent aggregate arguments (failed)
   ignore_errors: true
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"
   register: result
   vyos.vyos.vyos_interface:
     aggregate:
@@ -157,4 +159,4 @@
       - result.failed == true
       - "'host dummy_host' in result.failed_conditions"
       - "'port dummy_port' in result.failed_conditions"
-  when: run_lldp_tests
+  when: "'PortDescr:    eth0' in neighbors_out.stdout[0]"


### PR DESCRIPTION

Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY

In devel when set_fact is used to assign a bool value to a variable using a condition, the variable is assigned with the condition statement as a str instead of the result of the condition. Hence removing the usage of set_fact from the test.



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
/tests/integration/targets/vyos_interface

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
