### PR TITLE
Update terminal ansi_re

### DIFF
--- a/changelogs/fragments/terminal-escape-codes.yaml
+++ b/changelogs/fragments/terminal-escape-codes.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - terminal plugin - Overhaul ansi_re to remove more escape sequences

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -50,7 +50,7 @@ class TerminalModule(TerminalBase):
         # Xterm change keypad (ESC [=|>])
         re.compile(br"\x1b(=|>)"),
         # Xterm window title string (OSC <title string> BEL)
-        re.compile(br"\x1b]0;.*\x07"),
+        re.compile(br"\x1b]0;[^\x07]*\x07"),
     ]
 
     try:

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -40,10 +40,17 @@ class TerminalModule(TerminalBase):
         re.compile(br"\n\s+Set failed"),
     ]
 
-    ansi_re = [
-        re.compile(br"\x1b\[\?1h\x1b="),  # CSI ? 1 h ESC =
-        re.compile(br"\x08."),  # [Backspace] .
-        re.compile(br"\x1b\[m"),  # ANSI reset code
+    ansi_re = TerminalBase.ansi_re + [
+        # Color codes
+        re.compile(br"\x1b\[(\d+(;\d+)*)?m"),
+        # Clear line (CSI K)
+        re.compile(br"\x1b\[K"),
+        # Xterm change cursor mode (CSI ? 1 [h|l])
+        re.compile(br"\x1b\[\?1(h|l)"),
+        # Xterm change keypad (ESC [=|>])
+        re.compile(br"\x1b(=|>)"),
+        # Xterm window title string (OSC <title string> BEL)
+        re.compile(br"\x1b]0;.*\x07"),
     ]
 
     try:


### PR DESCRIPTION
##### SUMMARY

* Split CSI ? 1 h ESC = to support both normal and application mode
  sequences
* Expand matches for color code sequence
* Add Xterm window title sequence

Also take another stab at trying to document these regexes better.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/vyos.py

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/667
Depends-On: https://github.com/ansible-collections/vyos.vyos/pull/89