### PR TITLE
vyos_config: Fix config being processed as command

### DIFF
--- a/changelogs/fragments/config-processed-as-command.yaml
+++ b/changelogs/fragments/config-processed-as-command.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vyos_config - Only process src files as commands when they actually contain commands. This fixes an issue were the whitespace preceding a configuration key named 'set' was stripped, tripping up the parser.

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -209,7 +209,11 @@ def get_candidate(module):
     contents = module.params["src"] or module.params["lines"]
 
     if module.params["src"]:
-        contents = format_commands(contents.splitlines())
+        contents = contents.splitlines()
+        if len(contents) > 0:
+            line = contents[0].split()
+            if len(line) > 0 and line[0] in ("set", "delete"):
+                contents = format_commands(contents)
 
     contents = "\n".join(contents)
     return contents

--- a/tests/unit/modules/network/vyos/fixtures/vyos_config_src_brackets.cfg
+++ b/tests/unit/modules/network/vyos/fixtures/vyos_config_src_brackets.cfg
@@ -8,6 +8,15 @@ interfaces {
         disable
     }
 }
+policy {
+    route testroute {
+        rule 1 {
+            set {
+                table 10
+            }
+        }
+    }
+}
 system {
     host-name foo
 }

--- a/tests/unit/modules/network/vyos/test_vyos_config.py
+++ b/tests/unit/modules/network/vyos/test_vyos_config.py
@@ -106,16 +106,12 @@ class TestVyosConfigModule(TestVyosModule):
     def test_vyos_config_src_brackets(self):
         src = load_fixture("vyos_config_src_brackets.cfg")
         set_module_args(dict(src=src))
-        candidate = "\n".join(self.module.format_commands(src.splitlines()))
         commands = [
             "set interfaces ethernet eth0 address 10.10.10.10/24",
+            "set policy route testroute rule 1 set table 10",
             "set system host-name foo",
         ]
-        self.conn.get_diff = MagicMock(
-            return_value=self.cliconf_obj.get_diff(
-                candidate, self.running_config
-            )
-        )
+        self.conn.get_diff = MagicMock(side_effect=self.cliconf_obj.get_diff)
         self.execute_module(changed=True, commands=commands)
 
     def test_vyos_config_backup(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `vyos_config` module strips all whitespace in front of the string `set`, when it is a config key. This causes the route policy part of the VyOS config to be parsed incorrectly. For example:
```
policy {
  route someroute {
    rule 1 {
      set {
        table 10
      }
    }
  }
}
```
becomes:
```
policy {
  route someroute {
    rule 1 {
set {
        table 10
      }
    }
  }
}
```
which in turn breaks the assumption that child configuration is always indented relative to the parent.

The culprit is this line in the `format_commands` function: https://github.com/ansible-collections/vyos.vyos/blob/main/plugins/modules/vyos_config.py#L226

Eventually, the parser here parses the line incorrectly: https://github.com/ansible-collections/ansible.netcommon/blob/main/plugins/module_utils/network/common/config.py#L224

This seems to be caused by this line: https://github.com/ansible-collections/vyos.vyos/blob/main/plugins/modules/vyos_config.py#L211. Seeing that `format_commands` expects commands as input, and not configuration, and currently it processes configuration instead of commands, it seems a simple fix to just check whether `src` points to a file with commands, or configuration.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`vyos_config`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
