### PR TITLE
Remove ansible from requirements package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ansible
 ansible-pylibssh
 paramiko


### PR DESCRIPTION
Due to how ansible / ansible-base works we need to stop doing this right
now. Until we can build our own fake 'ansible' package of ansible-base.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>