### PR TITLE
Fixes #107 - port-groups typo.

### DIFF
--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -349,7 +349,7 @@ class Firewall_global(ConfigBase):
                 h_grp = h.get("group") or {}
             if w:
                 commands.extend(
-                    self._render_grp_mem("port-group", w["group"], h_grp, opr)
+                    self._render_grp_mem("port_group", w["group"], h_grp, opr)
                 )
                 commands.extend(
                     self._render_grp_mem(


### PR DESCRIPTION
Fixes #107 

Port-groups should use an underscore, as it's using a - it is never
picked up when compiling the commands to send.

Signed-Off-By: Rob Thomas <xrobau@gmail.com>
