### PR TITLE
Remove reliance on netcommon's ipaddress

### DIFF
--- a/changelogs/fragments/120-remove-ipaddress.yaml
+++ b/changelogs/fragments/120-remove-ipaddress.yaml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - ipaddress is no longer in ansible.netcommon. For Python versions without ipaddress (< 3.0), the ipaddress package is now required.

--- a/plugins/module_utils/network/vyos/utils/utils.py
+++ b/plugins/module_utils/network/vyos/utils/utils.py
@@ -8,9 +8,14 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 from ansible.module_utils.six import iteritems
-from ansible_collections.ansible.netcommon.plugins.module_utils.compat import (
-    ipaddress,
-)
+from ansible.module_utils.basic import missing_required_lib
+
+try:
+    import ipaddress
+
+    HAS_IPADDRESS = True
+except ImportError:
+    HAS_IPADDRESS = False
 
 
 def search_obj_in_list(name, lst, key="name"):
@@ -212,6 +217,9 @@ def get_ip_address_version(address):
     :param address: IP address
     :return:
     """
+    if not HAS_IPADDRESS:
+        raise Exception(missing_required_lib("ipaddress"))
+
     try:
         address = unicode(address)
     except NameError:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The vendored version will be disappearing in 2.0.0

I'm not sure what this looks like if you run l3_interfaces from Python < 3

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
