### PR TITLE
Subsequent calls to get_capabilities are duplicating entries in `rpc`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Name | Description
 Name | Description
 --- | ---
 
+### Inventory plugins
+Name | Description
+--- | ---
+
 ### Modules
 Name | Description
 --- | ---
@@ -63,10 +67,6 @@ Name | Description
 [vyos.vyos.vyos_system](https://github.com/ansible-collections/vyos.vyos/blob/main/docs/vyos.vyos.vyos_system_module.rst)|Run `set system` commands on VyOS devices
 [vyos.vyos.vyos_user](https://github.com/ansible-collections/vyos.vyos/blob/main/docs/vyos.vyos.vyos_user_module.rst)|Manage the collection of local users on VyOS device
 [vyos.vyos.vyos_vlan](https://github.com/ansible-collections/vyos.vyos/blob/main/docs/vyos.vyos.vyos_vlan_module.rst)|Manage VLANs on VyOS network devices
-
-### Inventory plugins
-Name | Description
---- | ---
 
 <!--end collection content-->
 

--- a/changelogs/fragments/122-rpc-unbloat.yaml
+++ b/changelogs/fragments/122-rpc-unbloat.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cliconf plugin - Prevent `get_capabilities()` from getting larger every time it is called

--- a/docs/vyos.vyos.vyos_banner_module.rst
+++ b/docs/vyos.vyos.vyos_banner_module.rst
@@ -220,7 +220,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure the pre-login banner
       vyos.vyos.vyos_banner:

--- a/docs/vyos.vyos.vyos_command_module.rst
+++ b/docs/vyos.vyos.vyos_command_module.rst
@@ -255,7 +255,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: show configuration on ethernet devices eth0 and eth1
       vyos.vyos.vyos_command:

--- a/docs/vyos.vyos.vyos_config_module.rst
+++ b/docs/vyos.vyos.vyos_config_module.rst
@@ -333,7 +333,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure the remote device
       vyos.vyos.vyos_config:

--- a/docs/vyos.vyos.vyos_facts_module.rst
+++ b/docs/vyos.vyos.vyos_facts_module.rst
@@ -199,7 +199,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Gather all facts
     - vyos.vyos.vyos_facts:

--- a/docs/vyos.vyos.vyos_firewall_global_module.rst
+++ b/docs/vyos.vyos.vyos_firewall_global_module.rst
@@ -783,7 +783,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_firewall_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_firewall_interfaces_module.rst
@@ -216,7 +216,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_firewall_rules_module.rst
+++ b/docs/vyos.vyos.vyos_firewall_rules_module.rst
@@ -1327,7 +1327,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using deleted to delete firewall rules based on rule-set name
     #

--- a/docs/vyos.vyos.vyos_interface_module.rst
+++ b/docs/vyos.vyos.vyos_interface_module.rst
@@ -572,7 +572,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure interface
       vyos.vyos.vyos_interface:

--- a/docs/vyos.vyos.vyos_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_interfaces_module.rst
@@ -319,7 +319,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_l3_interface_module.rst
+++ b/docs/vyos.vyos.vyos_l3_interface_module.rst
@@ -322,7 +322,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Set eth0 IPv4 address
       vyos.vyos.vyos_l3_interface:

--- a/docs/vyos.vyos.vyos_l3_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_l3_interfaces_module.rst
@@ -303,7 +303,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_lag_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_lag_interfaces_module.rst
@@ -273,7 +273,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_linkagg_module.rst
+++ b/docs/vyos.vyos.vyos_linkagg_module.rst
@@ -348,7 +348,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure link aggregation group
       vyos.vyos.vyos_linkagg:

--- a/docs/vyos.vyos.vyos_lldp_global_module.rst
+++ b/docs/vyos.vyos.vyos_lldp_global_module.rst
@@ -180,7 +180,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_lldp_interface_module.rst
+++ b/docs/vyos.vyos.vyos_lldp_interface_module.rst
@@ -264,7 +264,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Enable LLDP on eth1
       net_lldp_interface:

--- a/docs/vyos.vyos.vyos_lldp_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_lldp_interfaces_module.rst
@@ -370,7 +370,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_lldp_module.rst
+++ b/docs/vyos.vyos.vyos_lldp_module.rst
@@ -209,7 +209,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Enable LLDP service
       vyos.vyos.vyos_lldp:

--- a/docs/vyos.vyos.vyos_logging_module.rst
+++ b/docs/vyos.vyos.vyos_logging_module.rst
@@ -360,7 +360,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure console logging
       vyos.vyos.vyos_logging:

--- a/docs/vyos.vyos.vyos_ospf_interfaces_module.rst
+++ b/docs/vyos.vyos.vyos_ospf_interfaces_module.rst
@@ -461,7 +461,7 @@ Parameters
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_ospfv2_module.rst
+++ b/docs/vyos.vyos.vyos_ospfv2_module.rst
@@ -1649,7 +1649,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_ospfv3_module.rst
+++ b/docs/vyos.vyos.vyos_ospfv3_module.rst
@@ -348,7 +348,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_ping_module.rst
+++ b/docs/vyos.vyos.vyos_ping_module.rst
@@ -284,7 +284,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Test reachability to 10.10.10.10
       vyos.vyos.vyos_ping:
@@ -405,7 +405,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>The round trip time (RTT) stats.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">AnsibleMapping([(&#x27;avg&#x27;, 2), (&#x27;max&#x27;, 8), (&#x27;min&#x27;, 1), (&#x27;mdev&#x27;, 24)])</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;avg&#x27;: 2, &#x27;max&#x27;: 8, &#x27;min&#x27;: 1, &#x27;mdev&#x27;: 24}</div>
                 </td>
             </tr>
     </table>

--- a/docs/vyos.vyos.vyos_static_route_module.rst
+++ b/docs/vyos.vyos.vyos_static_route_module.rst
@@ -354,7 +354,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure static route
       vyos.vyos.vyos_static_route:

--- a/docs/vyos.vyos.vyos_static_routes_module.rst
+++ b/docs/vyos.vyos.vyos_static_routes_module.rst
@@ -343,7 +343,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     # Using merged
     #

--- a/docs/vyos.vyos.vyos_system_module.rst
+++ b/docs/vyos.vyos.vyos_system_module.rst
@@ -248,7 +248,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: configure hostname and domain-name
       vyos.vyos.vyos_system:

--- a/docs/vyos.vyos.vyos_user_module.rst
+++ b/docs/vyos.vyos.vyos_user_module.rst
@@ -408,7 +408,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: create a new user
       vyos.vyos.vyos_user:

--- a/docs/vyos.vyos.vyos_vlan_module.rst
+++ b/docs/vyos.vyos.vyos_vlan_module.rst
@@ -434,7 +434,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
 
     - name: Create vlan
       vyos.vyos.vyos_vlan:

--- a/plugins/cliconf/vyos.py
+++ b/plugins/cliconf/vyos.py
@@ -58,6 +58,13 @@ from ansible.plugins.cliconf import CliconfBase
 
 
 class Cliconf(CliconfBase):
+    __rpc__ = CliconfBase.__rpc__ + [
+        "commit",
+        "discard_changes",
+        "get_diff",
+        "run_commands",
+    ]
+
     def __init__(self, *args, **kwargs):
         super(Cliconf, self).__init__(*args, **kwargs)
         self._device_info = {}
@@ -339,12 +346,6 @@ class Cliconf(CliconfBase):
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
-        result["rpc"] += [
-            "commit",
-            "discard_changes",
-            "get_diff",
-            "run_commands",
-        ]
         result["device_operations"] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)


### PR DESCRIPTION
That should not be happening

This is probably also a problem on other platforms?

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without this change, the result of `get_capabilities` grows from
```paste below
{"rpc": ["edit_config", "disable_response_logging", "get_capabilities", "get_diff", "run_commands", "commit",
"discard_changes", "get", "get_config", "enable_response_logging"], "device_info": {"network_os": "vyos", 
"network_os_version": "VyOS 1.4-rolling-202102030218", "network_os_hostname": "vyos"}, "network_api": "cliconf", 
"device_operations": {"supports_diff_replace": false, "supports_commit": true, "supports_rollback": false, 
"supports_defaults": false, "supports_onbox_diff": true, "supports_commit_comment": true, "supports_multiline_delimiter": false, 
"supports_diff_match": true, "supports_diff_ignore_lines": false, "supports_generate_diff": false, "supports_replace": false}, 
"format": ["text", "set"], "diff_match": ["line", "none"], "diff_replace": [], "output": []}
```

to

```
{"rpc": ["get_config", "edit_config", "get_capabilities", "get", "enable_response_logging", "disable_response_logging", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands", "commit", "discard_changes", "get_diff", "run_commands", "commit", 
"discard_changes", "get_diff", "run_commands"], "device_info": {"network_os": "vyos", "network_os_version": "VyOS 1.1.8", 
"network_os_model": "OpenStack", "network_os_hostname": "vyos-1"}, "network_api": "cliconf", "device_operations": 
{"supports_diff_replace": false, "supports_commit": true, "supports_rollback": false, "supports_defaults": false, 
"supports_onbox_diff": true, "supports_commit_comment": true, "supports_multiline_delimiter": false, "supports_diff_match": true, 
"supports_diff_ignore_lines": false, "supports_generate_diff": false, "supports_replace": false}, "format": ["text", "set"], "diff_match": 
["line", "none"], "diff_replace": [], "output": []}
```