### PR TITLE
Add support for single_user_mode

### DIFF
--- a/changelogs/fragments/single_user_mode.yaml
+++ b/changelogs/fragments/single_user_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add support for configuration caching (single_user_mode).
+  - Re-use device_info dictionary in cliconf.

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -53,6 +53,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"\x1b]0;[^\x07]*\x07"),
     ]
 
+    terminal_config_prompt = re.compile(r"^.+#$")
+
     try:
         terminal_length = os.getenv("ANSIBLE_VYOS_TERMINAL_LENGTH", 10000)
         terminal_length = int(terminal_length)

--- a/tests/integration/targets/vyos_smoke/aliases
+++ b/tests/integration/targets/vyos_smoke/aliases
@@ -1,0 +1,1 @@
+shippable/vyos/group1

--- a/tests/integration/targets/vyos_smoke/defaults/main.yaml
+++ b/tests/integration/targets/vyos_smoke/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: '*'
+test_items: []

--- a/tests/integration/targets/vyos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/vyos_smoke/tasks/cli.yaml
@@ -1,0 +1,18 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: '{{ role_path }}/tests/cli'
+    patterns: '{{ testcase }}.yaml'
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case with single_user_mode (connection=network_cli)
+  include: '{{ test_case_to_run }} ansible_connection=network_cli ansible_network_single_user_mode=True'
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run
+  tags:
+    - network_cli

--- a/tests/integration/targets/vyos_smoke/tasks/main.yaml
+++ b/tests/integration/targets/vyos_smoke/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- include: cli.yaml

--- a/tests/integration/targets/vyos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/vyos_smoke/tests/cli/caching.yaml
@@ -1,0 +1,85 @@
+---
+- block:
+  - debug: msg="START connection={{ ansible_connection }} cli/caching.yaml"
+
+  - set_fact:
+      interface_cmds:
+        - set interfaces ethernet eth1 description 'Configured by Ansible - Interface 1'
+        - set interfaces ethernet eth1 mtu '1500'
+        - set interfaces ethernet eth1 duplex 'auto'
+        - set interfaces ethernet eth1 speed 'auto'
+        - set interfaces ethernet eth1 vif 101 description 'Eth1 - VIF 101'
+        - set interfaces ethernet eth2 description 'Configured by Ansible - Interface 2 (ADMIN DOWN)'
+        - set interfaces ethernet eth2 mtu '600'
+      l3_interface_cmds:
+        - set interfaces ethernet eth1 address '192.0.2.10/24'
+        - set interfaces ethernet eth1 address '2001:db8::10/32'
+        - set interfaces ethernet eth2 address '198.51.100.10/24'
+
+  - name: Remove interfaces from config before actual testing
+    ignore_errors: true
+    vyos.vyos.vyos_config: &rem
+      lines:
+        - delete interfaces ethernet eth1
+        - delete interfaces ethernet eth2
+      match: none
+
+  - name: Merge base interfaces configuration
+    register: result
+    vyos.vyos.vyos_interfaces: &merged
+      config:
+        - name: eth1
+          description: Configured by Ansible - Interface 1
+          mtu: 1500
+          speed: auto
+          duplex: auto
+          vifs:
+            - vlan_id: 101
+              description: Eth1 - VIF 101
+
+        - name: eth2
+          description: Configured by Ansible - Interface 2 (ADMIN DOWN)
+          mtu: 600
+      state: merged
+
+  - assert:
+      that:
+        - "{{ interface_cmds | symmetric_difference(result['commands']) |length == 0 }}"
+
+  - name: Merge base interfaces configuration (IDEMPOTENT)
+    register: result
+    vyos.vyos.vyos_interfaces: *merged
+
+  - assert:
+      that:
+        - result.changed == False
+
+  - name: Merge L3 interfaces configuration
+    register: result
+    vyos.vyos.vyos_l3_interfaces: &mergedl3
+      config:
+        - name: eth1
+          ipv4:
+            - address: 192.0.2.10/24
+          ipv6:
+            - address: 2001:db8::10/32
+        - name: eth2
+          ipv4:
+            - address: 198.51.100.10/24
+      state: merged
+
+  - assert:
+      that:
+        - "{{ l3_interface_cmds | symmetric_difference(result['commands']) |length == 0 }}"
+
+  - name: Merge L3 interfaces configuration (IDEMPOTENT)
+    register: result
+    vyos.vyos.vyos_l3_interfaces: *mergedl3
+
+  - assert:
+      that:
+        - result.changed == False
+  always:
+    - name: cleanup
+      vyos.vyos.vyos_config: *rem
+  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
Depends-On: https://github.com/ansible-collections/vyos.vyos/pull/126

##### SUMMARY
- Targets ansible-collections/ansible.netcommon#73
- Add support for ansible_single_user_mode option added in network_cli.
- Re-use device_info dictionary for every session.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
terminal/vyos.py
cliconf/vyos.py
