### PR TITLE
Get `ansible-test` further along

### DIFF
--- a/changelogs/fragments/remove-old-test-deps.yml
+++ b/changelogs/fragments/remove-old-test-deps.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Removed old, unused dependencies from `tests/unit/requirements.txt`

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,42 +1,4 @@
-boto3
-placebo
-pycrypto
-passlib
-pypsrp
-python-memcached
-pytz
-pyvmomi
-redis
-requests
 setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools (sanity_ok)
 unittest2 ; python_version < '2.7'
 importlib ; python_version < '2.7'
-netaddr
-ipaddress
-netapp-lib
-solidfire-sdk-python
-
-# requirements for F5 specific modules
-f5-sdk ; python_version >= '2.7'
-f5-icontrol-rest ; python_version >= '2.7'
-deepdiff
-
-# requirement for Fortinet specific modules
-pyFMG
-
-# requirement for aci_rest module
-xmljson
-
-# requirement for winrm connection plugin tests
-pexpect
-
-# requirement for the linode module
-linode-python # APIv3
-linode_api4 ; python_version > '2.6' # APIv4
-
-# requirement for the gitlab module
-python-gitlab
-httmock
-
-# requirment for kubevirt modules
-openshift ; python_version >= '2.7'
+ipaddress ; python_version < '3.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This change removes a bunch of deps in `tests/unit/requirements.txt` that look to have been carried over and never cleaned up from when this was part of `community.general`.

Note: This still fails to actually run with `--docker default`, but it at least gets to the point of running the tests.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`vyos.vyos`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Tested with:
```
ansible-test \
  units \
  --docker default \
  -v \
  --python 3.6 \
  tests/unit/modules/network/vyos/test_vyos_firewall_global.py
```

Output without change: https://gist.github.com/sdwilsh/9adb2686beb8f4cf2e66520188a21b22

Output with change: https://gist.github.com/sdwilsh/88e5106baf804a6fd8656c44a789743f
