### PR TITLE
IPV6 ICMP type name in vyos.vyos.vyos_firewall_rules is not idempotent 

### DIFF
--- a/changelogs/fragments/fix_issue170_vyos_firewall_rules.yaml
+++ b/changelogs/fragments/fix_issue170_vyos_firewall_rules.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix issue in firewall rules facts code when IPV6 ICMP type name in vyos.vyos.vyos_firewall_rules is not idempotent

--- a/plugins/module_utils/network/vyos/facts/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/facts/firewall_rules/firewall_rules.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import re
 from re import findall, search, M
 from copy import deepcopy
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import (
@@ -167,6 +168,7 @@ class Firewall_rulesFacts(object):
             "fragment",
             "disabled",
             "description",
+            "icmp"
         ]
         rule = self.parse_attr(conf, a_lst)
         r_sub = {
@@ -282,6 +284,9 @@ class Firewall_rulesFacts(object):
         :return: generated config dictionary.
         """
         a_lst = ["code", "type", "type_name"]
+        if attrib == 'icmp':
+                attrib = 'icmpv6'
+        conf = re.sub('icmpv6 type', 'icmpv6 type-name',conf)    
         cfg_dict = self.parse_attr(conf, a_lst, match=attrib)
         return cfg_dict
 

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -80,6 +80,8 @@ class TestVyosFirewallRulesModule(TestVyosModule):
 
         self.execute_show_command.side_effect = load_from_file
 
+
+
     def test_vyos_firewall_rule_set_01_merged(self):
         set_module_args(
             dict(
@@ -139,6 +141,7 @@ class TestVyosFirewallRulesModule(TestVyosModule):
             "set firewall name V4-OUTBOUND description 'This is IPv4 OUTBOUND rule set'",
         ]
         self.execute_module(changed=True, commands=commands)
+
 
     def test_vyos_firewall_rule_set_02_merged(self):
         set_module_args(
@@ -243,6 +246,7 @@ class TestVyosFirewallRulesModule(TestVyosModule):
             "set firewall name INBOUND rule 101 ipsec 'match-ipsec'",
         ]
         self.execute_module(changed=True, commands=commands)
+
 
     def test_vyos_firewall_v4_rule_sets_rule_merged_02(self):
         set_module_args(
@@ -416,6 +420,9 @@ class TestVyosFirewallRulesModule(TestVyosModule):
                                         ipsec="match-ipsec",
                                         protocol="icmp",
                                         disabled=True,
+                                        icmp= dict(
+                                            type_name="echo-request"
+                                        )
                                     )
                                 ],
                             ),
@@ -435,6 +442,7 @@ class TestVyosFirewallRulesModule(TestVyosModule):
             "set firewall ipv6-name INBOUND rule 101 disabled",
             "set firewall ipv6-name INBOUND rule 101 action 'accept'",
             "set firewall ipv6-name INBOUND rule 101 ipsec 'match-ipsec'",
+            "set firewall ipv6-name INBOUND rule 101 icmpv6 type echo-request",
         ]
         self.execute_module(changed=True, commands=commands)
 
@@ -683,6 +691,7 @@ class TestVyosFirewallRulesModule(TestVyosModule):
         ]
         self.execute_module(changed=True, commands=commands)
 
+
     def test_vyos_firewall_v4_rule_sets_del_01(self):
         set_module_args(
             dict(
@@ -879,7 +888,7 @@ class TestVyosFirewallRulesModule(TestVyosModule):
                         rule_sets=[
                             dict(
                                 name="V6-INGRESS",
-                                default_action="accept",
+                                default_action="accept",                               
                             ),
                             dict(
                                 name="V6-EGRESS",
@@ -928,11 +937,11 @@ class TestVyosFirewallRulesModule(TestVyosModule):
                         rule_sets=[
                             dict(
                                 name="V6-INGRESS",
-                                default_action="accept",
+                                default_action="accept",                               
                             ),
                             dict(
                                 name="V6-EGRESS",
-                                default_action="reject",
+                                default_action="reject",                              
                             ),
                         ],
                     ),
@@ -1078,3 +1087,5 @@ class TestVyosFirewallRulesModule(TestVyosModule):
             )
         )
         self.execute_module(changed=False, commands=[])
+
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

fix issue: #170

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
