### PR TITLE
Drop ansible_become for testing

### DIFF
--- a/changelogs/fragments/tests_become.yaml
+++ b/changelogs/fragments/tests_become.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Remove ansible_become usage from integration testing.

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/deleted.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/deleted.yaml
@@ -23,8 +23,7 @@
                 - afi: "ipv6"
         state: deleted
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/gathered.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/gathered.yaml
@@ -14,8 +14,7 @@
       vyos.vyos.vyos_bgp_address_family:
         state: gathered
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/merged.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/merged.yaml
@@ -41,8 +41,7 @@
                       route_map: "map01"
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/overridden.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/overridden.yaml
@@ -32,8 +32,7 @@
                       acl: 10
         state: overridden
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/parsed.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/parsed.yaml
@@ -4,7 +4,6 @@
       }}
 
 - name: Provide the running configuration for parsing (config to be parsed)
-  become: true
   register: result
   vyos.vyos.vyos_bgp_address_family:
     running_config: "{{ lookup('file', '_parsed_config.cfg') }}"

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/replaced.yaml
@@ -32,8 +32,7 @@
                       acl: 10
         state: replaced
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_address_family/tests/cli/rtt.yaml
+++ b/tests/integration/targets/vyos_bgp_address_family/tests/cli/rtt.yaml
@@ -41,8 +41,7 @@
                       route_map: "map01"
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_address_family
 
     - assert:
@@ -53,7 +52,6 @@
           - baseconfig.after == ansible_facts['network_resources']['bgp_address_family']
 
     - name: Apply the provided configuration (config to be reverted)
-      become: true
       register: result
       vyos.vyos.vyos_bgp_address_family:
         config:
@@ -73,7 +71,6 @@
               neighbor_address: "203.0.113.5"
 
     - name: Revert back to base config using facts round trip
-      become: true
       register: revert
       vyos.vyos.vyos_bgp_address_family:
         config: "{{ ansible_facts['network_resources']['bgp_address_family'] }}"

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/deleted.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/deleted.yaml
@@ -16,8 +16,7 @@
           as_number: "65536"
         state: deleted
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_global
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/gathered.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/gathered.yaml
@@ -14,8 +14,7 @@
       vyos.vyos.vyos_bgp_global:
         state: gathered
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_global
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/merged.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/merged.yaml
@@ -42,8 +42,7 @@
             router_id: "192.1.2.9"
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_global
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/parsed.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/parsed.yaml
@@ -4,7 +4,6 @@
       }}
 
 - name: Provide the running configuration for parsing (config to be parsed)
-  become: true
   register: result
   vyos.vyos.vyos_bgp_global:
     running_config: "{{ lookup('file', '_parsed_config.cfg') }}"

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/purged.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/purged.yaml
@@ -16,8 +16,7 @@
           as_number: "65536"
         state: purged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_global
 
     - assert:

--- a/tests/integration/targets/vyos_bgp_global/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_bgp_global/tests/cli/replaced.yaml
@@ -46,8 +46,7 @@
                 orf: "receive"
         state: replaced
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: bgp_global
 
     - assert:

--- a/tests/integration/targets/vyos_config/tests/cli/backup.yaml
+++ b/tests/integration/targets/vyos_config/tests/cli/backup.yaml
@@ -43,7 +43,6 @@
     - '{{ role_path }}/backup/backup.cfg'
 
 - name: take configuration backup in custom filename and directory path
-  become: true
   register: result
   vyos.vyos.vyos_config:
     backup: true
@@ -66,7 +65,6 @@
       - backup_file.files is defined
 
 - name: take configuration backup in custom filename
-  become: true
   register: result
   vyos.vyos.vyos_config:
     backup: true
@@ -88,7 +86,6 @@
       - backup_file.files is defined
 
 - name: take configuration backup in custom path and default filename
-  become: true
   register: result
   vyos.vyos.vyos_config:
     backup: true

--- a/tests/integration/targets/vyos_config/tests/cli_config/cli_backup.yaml
+++ b/tests/integration/targets/vyos_config/tests/cli_config/cli_backup.yaml
@@ -23,7 +23,6 @@
   with_items: '{{backup_files.files|default([])}}'
 
 - name: take config backup
-  become: true
   register: result
   ansible.netcommon.cli_config:
     backup: true
@@ -44,7 +43,6 @@
       - backup_files.files is defined
 
 - name: take configuration backup in custom filename and directory path
-  become: true
   register: result
   ansible.netcommon.cli_config:
     backup: true
@@ -67,7 +65,6 @@
       - backup_file.files is defined
 
 - name: take configuration backup in custom filename
-  become: true
   register: result
   ansible.netcommon.cli_config:
     backup: true
@@ -89,7 +86,6 @@
       - backup_file.files is defined
 
 - name: take configuration backup in custom path and default filename
-  become: true
   register: result
   ansible.netcommon.cli_config:
     backup: true

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/deleted.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/deleted.yaml
@@ -16,8 +16,7 @@
           - name: "bond2"
         state: deleted
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/gathered.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/gathered.yaml
@@ -14,8 +14,7 @@
       vyos.vyos.vyos_ospf_interfaces:
         state: gathered
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/merged.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/merged.yaml
@@ -26,8 +26,7 @@
                 passive: true
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/overridden.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/overridden.yaml
@@ -23,8 +23,7 @@
                 dead_interval: 39
         state: overridden
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/parsed.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/parsed.yaml
@@ -4,7 +4,6 @@
       }}
 
 - name: Provide the running configuration for parsing (config to be parsed)
-  become: true
   register: result
   vyos.vyos.vyos_ospf_interfaces:
     running_config: "{{ lookup('file', '_parsed.cfg') }}"

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/replaced.yaml
@@ -34,8 +34,7 @@
                 passive: true
         state: replaced
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:

--- a/tests/integration/targets/vyos_ospf_interfaces/tests/cli/rtt.yaml
+++ b/tests/integration/targets/vyos_ospf_interfaces/tests/cli/rtt.yaml
@@ -26,8 +26,7 @@
                 passive: true
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: ospf_interfaces
 
     - assert:
@@ -38,7 +37,6 @@
           - baseconfig.after|symmetric_difference(ansible_facts['network_resources']['ospf_interfaces']) == []
 
     - name: Apply the provided configuration (config to be reverted)
-      become: true
       register: result
       vyos.vyos.vyos_ospf_interfaces:
         config:
@@ -52,7 +50,6 @@
                 dead_interval: 39
 
     - name: Revert back to base config using facts round trip
-      become: true
       register: revert
       vyos.vyos.vyos_ospf_interfaces:
         config: "{{ ansible_facts['network_resources']['ospf_interfaces'] }}"

--- a/tests/integration/targets/vyos_route_maps/tests/cli/gathered.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/gathered.yaml
@@ -14,8 +14,7 @@
       vyos.vyos.vyos_route_maps:
         state: gathered
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: route_maps
 
     - assert:

--- a/tests/integration/targets/vyos_route_maps/tests/cli/merged.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/merged.yaml
@@ -33,8 +33,7 @@
                   weight: 4
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: route_maps
 
     - assert:

--- a/tests/integration/targets/vyos_route_maps/tests/cli/overridden.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/overridden.yaml
@@ -30,8 +30,7 @@
                   weight: 4
         state: overridden
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: route_maps
 
     - assert:

--- a/tests/integration/targets/vyos_route_maps/tests/cli/parsed.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/parsed.yaml
@@ -4,7 +4,6 @@
       }}
 
 - name: Provide the running configuration for parsing (config to be parsed)
-  become: true
   register: result
   vyos.vyos.vyos_route_maps:
     running_config: "{{ lookup('file', '_parsed.cfg') }}"

--- a/tests/integration/targets/vyos_route_maps/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/replaced.yaml
@@ -29,8 +29,7 @@
                   weight: 4
         state: replaced
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: route_maps
 
     - assert:

--- a/tests/integration/targets/vyos_route_maps/tests/cli/rtt.yaml
+++ b/tests/integration/targets/vyos_route_maps/tests/cli/rtt.yaml
@@ -33,8 +33,7 @@
                   weight: 4
         state: merged
 
-    - become: true
-      vyos.vyos.vyos_facts:
+    - vyos.vyos.vyos_facts:
         gather_network_resources: route_maps
 
     - assert:
@@ -65,7 +64,6 @@
                   weight: 4
 
     - name: Revert back to base config using facts round trip
-      become: true
       register: revert
       vyos.vyos.vyos_route_maps:
         config: "{{ ansible_facts['network_resources']['route_maps'] }}"


### PR DESCRIPTION
We don't actually need escalated permissions to run these things.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>