### PR TITLE
Fix `vyos.vyos.vyos_firewall_rules` `state: replaced` to match documentation

### DIFF
--- a/changelogs/fragments/fix-firewall_rules-state-replaced.yaml
+++ b/changelogs/fragments/fix-firewall_rules-state-replaced.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix vyos_firewall_rules with state replaced to only replace the specified rules.

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -178,12 +178,17 @@ class Firewall_rules(ConfigBase):
                     wanted_rule_set = self.search_r_sets_in_target(
                         want, rs["name"], "r_list"
                     )
-                    # Remove the rules that we already have for this rule set.
-                    commands.extend(
-                        self._add_r_sets(
-                            h["afi"], want=rs, have=wanted_rule_set, opr=False
+                    if wanted_rule_set is not None:
+                        # Remove the rules that we already have if the wanted
+                        # rules exist under the same name.
+                        commands.extend(
+                            self._add_r_sets(
+                                h["afi"],
+                                want=rs,
+                                have=wanted_rule_set,
+                                opr=False,
+                            )
                         )
-                    )
         # Merge the desired configuration into what we already have.
         commands.extend(self._state_merged(want, have))
         return commands

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -205,7 +205,8 @@ class Firewall_rules(ConfigBase):
             for h in have:
                 r_sets = self._get_r_sets(h)
                 for rs in r_sets:
-                    w = self.search_r_sets_in_target(want, rs["name"], "r_list")
+                    w = self.search_r_sets_in_target(
+                        want, rs["name"], "r_list")
                     if not w:
                         commands.append(
                             self._compute_command(

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -175,7 +175,7 @@ class Firewall_rules(ConfigBase):
                     # In the desired configuration, search for the rule set we
                     # already have (to be replaced by our desired
                     # configuration's rule set).
-                    wanted_rule_set = self.search_r_sets_in_target(
+                    wanted_rule_set = self.search_r_sets_in_have(
                         want, rs["name"], "r_list"
                     )
                     if wanted_rule_set is not None:
@@ -205,7 +205,7 @@ class Firewall_rules(ConfigBase):
             for h in have:
                 r_sets = self._get_r_sets(h)
                 for rs in r_sets:
-                    w = self.search_r_sets_in_target(
+                    w = self.search_r_sets_in_have(
                         want, rs["name"], "r_list")
                     if not w:
                         commands.append(
@@ -231,7 +231,7 @@ class Firewall_rules(ConfigBase):
         for w in want:
             r_sets = self._get_r_sets(w)
             for rs in r_sets:
-                h = self.search_r_sets_in_target(have, rs["name"], "r_list")
+                h = self.search_r_sets_in_have(have, rs["name"], "r_list")
                 commands.extend(self._add_r_sets(w["afi"], rs, h))
         return commands
 
@@ -248,7 +248,7 @@ class Firewall_rules(ConfigBase):
                 r_sets = self._get_r_sets(w)
                 if r_sets:
                     for rs in r_sets:
-                        h = self.search_r_sets_in_target(
+                        h = self.search_r_sets_in_have(
                             have, rs["name"], "r_list"
                         )
                         if h:
@@ -361,7 +361,7 @@ class Firewall_rules(ConfigBase):
         if w_rules:
             for w in w_rules:
                 cmd = self._compute_command(afi, name, w["number"], opr=opr)
-                h = self.search_r_sets_in_target(
+                h = self.search_r_sets_in_have(
                     h_rules, w["number"], type="rules"
                 )
                 for key, val in iteritems(w):
@@ -842,7 +842,7 @@ class Firewall_rules(ConfigBase):
                             )
         return commands
 
-    def search_r_sets_in_target(self, target, w_name, type="rule_sets"):
+    def search_r_sets_in_have(self, have, w_name, type="rule_sets"):
         """
         This function  returns the rule-set/rule if it is present in target config.
         :param have: target config.
@@ -850,21 +850,21 @@ class Firewall_rules(ConfigBase):
         :param type: rule_sets/rule/r_list.
         :return: rule-set/rule.
         """
-        if target:
+        if have:
             key = "name"
             if type == "rules":
                 key = "number"
-                for r in target:
+                for r in have:
                     if r[key] == w_name:
                         return r
             elif type == "r_list":
-                for t in target:
-                    r_sets = self._get_r_sets(t)
+                for h in have:
+                    r_sets = self._get_r_sets(h)
                     for rs in r_sets:
                         if rs[key] == w_name:
                             return rs
             else:
-                for rs in target:
+                for rs in have:
                     if rs[key] == w_name:
                         return rs
         return None

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -205,8 +205,7 @@ class Firewall_rules(ConfigBase):
             for h in have:
                 r_sets = self._get_r_sets(h)
                 for rs in r_sets:
-                    w = self.search_r_sets_in_have(
-                        want, rs["name"], "r_list")
+                    w = self.search_r_sets_in_have(want, rs["name"], "r_list")
                     if not w:
                         commands.append(
                             self._compute_command(

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -167,13 +167,24 @@ class Firewall_rules(ConfigBase):
         """
         commands = []
         if have:
+            # Iterate over the afi rule sets we already have.
             for h in have:
                 r_sets = self._get_r_sets(h)
+                # Iterate over each rule set we already have.
                 for rs in r_sets:
-                    w = self.search_r_sets_in_target(want, rs["name"], "r_list")
-                    commands.extend(
-                        self._add_r_sets(h["afi"], rs, w, opr=False)
+                    # In the desired configuration, search for the rule set we
+                    # already have (to be replaced by our desired
+                    # configuration's rule set).
+                    wanted_rule_set = self.search_r_sets_in_target(
+                        want, rs["name"], "r_list"
                     )
+                    # Remove the rules that we already have for this rule set.
+                    commands.extend(
+                        self._add_r_sets(
+                            h["afi"], want=rs, have=wanted_rule_set, opr=False
+                        )
+                    )
+        # Merge the desired configuration into what we already have.
         commands.extend(self._state_merged(want, have))
         return commands
 

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -170,7 +170,7 @@ class Firewall_rules(ConfigBase):
             for h in have:
                 r_sets = self._get_r_sets(h)
                 for rs in r_sets:
-                    w = self.search_r_sets_in_have(want, rs["name"], "r_list")
+                    w = self.search_r_sets_in_target(want, rs["name"], "r_list")
                     commands.extend(
                         self._add_r_sets(h["afi"], rs, w, opr=False)
                     )
@@ -189,7 +189,7 @@ class Firewall_rules(ConfigBase):
             for h in have:
                 r_sets = self._get_r_sets(h)
                 for rs in r_sets:
-                    w = self.search_r_sets_in_have(want, rs["name"], "r_list")
+                    w = self.search_r_sets_in_target(want, rs["name"], "r_list")
                     if not w:
                         commands.append(
                             self._compute_command(
@@ -214,7 +214,7 @@ class Firewall_rules(ConfigBase):
         for w in want:
             r_sets = self._get_r_sets(w)
             for rs in r_sets:
-                h = self.search_r_sets_in_have(have, rs["name"], "r_list")
+                h = self.search_r_sets_in_target(have, rs["name"], "r_list")
                 commands.extend(self._add_r_sets(w["afi"], rs, h))
         return commands
 
@@ -231,7 +231,7 @@ class Firewall_rules(ConfigBase):
                 r_sets = self._get_r_sets(w)
                 if r_sets:
                     for rs in r_sets:
-                        h = self.search_r_sets_in_have(
+                        h = self.search_r_sets_in_target(
                             have, rs["name"], "r_list"
                         )
                         if h:
@@ -344,7 +344,7 @@ class Firewall_rules(ConfigBase):
         if w_rules:
             for w in w_rules:
                 cmd = self._compute_command(afi, name, w["number"], opr=opr)
-                h = self.search_r_sets_in_have(
+                h = self.search_r_sets_in_target(
                     h_rules, w["number"], type="rules"
                 )
                 for key, val in iteritems(w):
@@ -825,7 +825,7 @@ class Firewall_rules(ConfigBase):
                             )
         return commands
 
-    def search_r_sets_in_have(self, have, w_name, type="rule_sets"):
+    def search_r_sets_in_target(self, target, w_name, type="rule_sets"):
         """
         This function  returns the rule-set/rule if it is present in target config.
         :param have: target config.
@@ -833,21 +833,21 @@ class Firewall_rules(ConfigBase):
         :param type: rule_sets/rule/r_list.
         :return: rule-set/rule.
         """
-        if have:
+        if target:
             key = "name"
             if type == "rules":
                 key = "number"
-                for r in have:
+                for r in target:
                     if r[key] == w_name:
                         return r
             elif type == "r_list":
-                for h in have:
-                    r_sets = self._get_r_sets(h)
+                for t in target:
+                    r_sets = self._get_r_sets(t)
                     for rs in r_sets:
                         if rs[key] == w_name:
                             return rs
             else:
-                for rs in have:
+                for rs in target:
                     if rs[key] == w_name:
                         return rs
         return None

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -842,52 +842,6 @@ class TestVyosFirewallRulesModule(TestVyosModule):
         ]
         self.execute_module(changed=True, commands=commands)
 
-    def test_vyos_firewall_v4v6_rule_sets_rule_rep_03(self):
-        set_module_args(
-            dict(
-                config=[
-                    dict(
-                        afi="ipv4",
-                        rule_sets=[
-                            dict(
-                                name="V4-INGRESS",
-                                description="This is IPv4 V4-INGRESS rule set",
-                                default_action="accept",
-                                enable_default_log=True,
-                                rules=[
-                                    dict(
-                                        number="101",
-                                        action="accept",
-                                        description="Rule 101 is configured by Ansible",
-                                        ipsec="match-ipsec",
-                                        protocol="icmp",
-                                        fragment="match-frag",
-                                        disabled=True,
-                                    ),
-                                    dict(
-                                        number="102",
-                                        action="accept",
-                                        description="Rule 102 is configured by Ansible",
-                                        protocol="icmp",
-                                        disabled=True,
-                                    ),
-                                ],
-                            ),
-                        ],
-                    ),
-                ],
-                state="replaced",
-            )
-        )
-        commands = [
-            "set firewall name V4-INGRESS rule 102 disabled",
-            "set firewall name V4-INGRESS rule 102 action 'accept'",
-            "set firewall name V4-INGRESS rule 102 protocol 'icmp'",
-            "set firewall name V4-INGRESS rule 102 description 'Rule 102 is configured by Ansible'",
-            "set firewall name V4-INGRESS rule 102",
-        ]
-        self.execute_module(changed=True, commands=commands)
-
     def test_vyos_firewall_v4v6_rule_sets_rule_rep_idem_01(self):
         set_module_args(
             dict(

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -844,6 +844,52 @@ class TestVyosFirewallRulesModule(TestVyosModule):
         ]
         self.execute_module(changed=True, commands=commands)
 
+    def test_vyos_firewall_v4v6_rule_sets_rule_rep_03(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        afi="ipv4",
+                        rule_sets=[
+                            dict(
+                                name="V4-INGRESS",
+                                description="This is IPv4 V4-INGRESS rule set",
+                                default_action="accept",
+                                enable_default_log=True,
+                                rules=[
+                                    dict(
+                                        number="101",
+                                        action="accept",
+                                        description="Rule 101 is configured by Ansible",
+                                        ipsec="match-ipsec",
+                                        protocol="icmp",
+                                        fragment="match-frag",
+                                        disabled=True,
+                                    ),
+                                    dict(
+                                        number="102",
+                                        action="accept",
+                                        description="Rule 102 is configured by Ansible",
+                                        protocol="icmp",
+                                        disabled=True,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            )
+        )
+        commands = [
+            "set firewall name V4-INGRESS rule 102 disabled",
+            "set firewall name V4-INGRESS rule 102 action 'accept'",
+            "set firewall name V4-INGRESS rule 102 protocol 'icmp'",
+            "set firewall name V4-INGRESS rule 102 description 'Rule 102 is configured by Ansible'",
+            "set firewall name V4-INGRESS rule 102",
+        ]
+        self.execute_module(changed=True, commands=commands)
+
     def test_vyos_firewall_v4v6_rule_sets_rule_rep_idem_01(self):
         set_module_args(
             dict(
@@ -884,6 +930,38 @@ class TestVyosFirewallRulesModule(TestVyosModule):
                             dict(
                                 name="V6-EGRESS",
                                 default_action="reject",
+                            ),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            )
+        )
+        self.execute_module(changed=False, commands=[])
+
+    def test_vyos_firewall_v4v6_rule_sets_rule_rep_idem_02(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        afi="ipv4",
+                        rule_sets=[
+                            dict(
+                                name="V4-INGRESS",
+                                description="This is IPv4 V4-INGRESS rule set",
+                                default_action="accept",
+                                enable_default_log=True,
+                                rules=[
+                                    dict(
+                                        number="101",
+                                        action="accept",
+                                        description="Rule 101 is configured by Ansible",
+                                        ipsec="match-ipsec",
+                                        protocol="icmp",
+                                        fragment="match-frag",
+                                        disabled=True,
+                                    ),
+                                ],
                             ),
                         ],
                     ),

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -780,7 +780,6 @@ class TestVyosFirewallRulesModule(TestVyosModule):
         )
         commands = [
             "delete firewall name V4-INGRESS rule 101 disabled",
-            "delete firewall name V4-EGRESS default-action",
             "set firewall name V4-INGRESS description 'This is IPv4 INGRESS rule set'",
             "set firewall name V4-INGRESS rule 101 protocol 'tcp'",
             "set firewall name V4-INGRESS rule 101 description 'Rule 101 is configured by Ansible RM'",
@@ -840,7 +839,6 @@ class TestVyosFirewallRulesModule(TestVyosModule):
         )
         commands = [
             "delete firewall name V4-INGRESS enable-default-log",
-            "delete firewall name V4-EGRESS default-action",
         ]
         self.execute_module(changed=True, commands=commands)
 


### PR DESCRIPTION
##### SUMMARY
`vyos.vyos.vyos_firewall_rules` should only try to change listed firewall rules, as documented, when the state is set to `replaced`.  As currently implemented (prior to this PR), it better matches what `overridden` is meant to do.

Fixes #201

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`vyos.vyos.vyos_firewall_rules`

##### ADDITIONAL INFORMATION

- [x] Cleanup and document existing code for clarity
- [x] Add a failing idempotent test
- [x] Add a failing change test
- [x] Fix failing tests
- [x] Add change fragment
