### PR TITLE
tests/vyos_user: ensure public key don't break the SSH test

### DIFF
--- a/tests/integration/targets/vyos_user/tests/cli/auth.yaml
+++ b/tests/integration/targets/vyos_user/tests/cli/auth.yaml
@@ -11,7 +11,7 @@
     - name: test login via ssh with new user
       expect:
         command: ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_port | default(22)
-          }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper
+          }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper
           show version'
         responses:
           (?i)password: pass123


### PR DESCRIPTION

Pass `-o PubkeyAuthentication=no` to SSH to be sure a public key cannot
interfert with the test result. Failure example:

```
 fatal: [vyos]: FAILED! => {
     "changed": true,
     "cmd": "ssh auth_user@199.204.45.57 -p 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'",
     "delta": "0:00:08.219018",
     "end": "2022-03-30 17:42:56.982936",
     "invocation": {
         "module_args": {
             "chdir": null,
             "command": "ssh auth_user@199.204.45.57 -p 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'",
             "creates": null,
             "echo": false,
             "removes": null,
             "responses": {
                 "(?i)password": "pass123"
             },
             "timeout": 30
         }
     },
     "msg": "non-zero return code",
     "rc": 255,
     "start": "2022-03-30 17:42:48.763918",
     "stdout": "Warning: Permanently added '199.204.45.57' (RSA) to the list of known hosts.\r\r\nWelcome to VyOS\r\nauth_user@199.204.45.57: Permission denied (publickey).",
     "stdout_lines": [
         "Warning: Permanently added '199.204.45.57' (RSA) to the list of known hosts.",
         "",
         "Welcome to VyOS",
         "auth_user@199.204.45.57: Permission denied (publickey)."
     ]
 }
 redirecting (type: action) vyos.vyos.vyos_user to vyos.vyos.vyos

```
