### PR TITLE
Add fqcn to ansible_connection to support stable-2.9

### DIFF
--- a/changelogs/fragments/add_fqcn_ansible_connection.yaml
+++ b/changelogs/fragments/add_fqcn_ansible_connection.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "change the ansible_connection to ansible.netcommon.network_cli (FQCN)"

--- a/tests/integration/targets/vyos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/vyos_smoke/tasks/cli.yaml
@@ -9,8 +9,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case with single_user_mode (connection=network_cli)
-  include: '{{ test_case_to_run }} ansible_connection=network_cli ansible_network_single_user_mode=True'
+- name: run test case with single_user_mode (connection=ansible.netcommon.network_cli)
+  include: '{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli ansible_network_single_user_mode=True'
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run

--- a/tests/integration/targets/vyos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/vyos_smoke/tests/cli/caching.yaml
@@ -82,4 +82,4 @@
   always:
     - name: cleanup
       vyos.vyos.vyos_config: *rem
-  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)
+  when: ansible_connection == "ansible.netcommon.network_cli" and ansible_network_single_user_mode|d(False)


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

strip_prompt argument is supported only in netcommon network_cli . Vyos jobs on stable-2.9 is failing with the following error, as this argument is not supported ansibe/ansible. This PR sets ansible_connection to ansible.netcommon.network_cli, so that the correct module is used.

```
2022-04-21 21:14:54.059623 | controller |     capabilities = Connection(module._socket_path).get_capabilities()
2022-04-21 21:14:54.059626 | controller |   File "/tmp/ansible_vyos.vyos.vyos_config_payload_hjioy2__/ansible_vyos.vyos.vyos_config_payload.zip/ansible/module_utils/connection.py", line 190, in __rpc__
2022-04-21 21:14:54.059629 | controller |     raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
2022-04-21 21:14:54.059632 | controller | fatal: [vyos]: FAILED! => {
2022-04-21 21:14:54.059635 | controller |     "changed": false,
2022-04-21 21:14:54.059638 | controller |     "invocation": {
2022-04-21 21:14:54.059641 | controller |         "module_args": {
2022-04-21 21:14:54.059644 | controller |             "backup": false,
2022-04-21 21:14:54.059647 | controller |             "backup_options": null,
2022-04-21 21:14:54.059650 | controller |             "comment": "configured by vyos_config",
2022-04-21 21:14:54.059653 | controller |             "config": null,
2022-04-21 21:14:54.059656 | controller |             "lines": [
2022-04-21 21:14:54.059658 | controller |                 "delete interfaces ethernet eth1",
2022-04-21 21:14:54.059661 | controller |                 "delete interfaces ethernet eth2"
2022-04-21 21:14:54.059664 | controller |             ],
2022-04-21 21:14:54.059667 | controller |             "match": "none",
2022-04-21 21:14:54.059670 | controller |             "provider": null,
2022-04-21 21:14:54.059673 | controller |             "save": false,
2022-04-21 21:14:54.059676 | controller |             "src": null
2022-04-21 21:14:54.059678 | controller |         }
2022-04-21 21:14:54.059682 | controller |     },
2022-04-21 21:14:54.059685 | controller |     "msg": "send() got an unexpected keyword argument 'strip_prompt'"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
