### PR TITLE
Allow override of terminal config command

### DIFF
--- a/changelogs/fragments/add-terminal-config-environment-variable.yaml
+++ b/changelogs/fragments/add-terminal-config-environment-variable.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add environment variable to override `set terminal` command (ANSIBLE_VYOS_TERMINAL_CONFIG_COMMAND) for use with EdgeOS.

--- a/docs/vyos.vyos.vyos_command_module.rst
+++ b/docs/vyos.vyos.vyos_command_module.rst
@@ -19,7 +19,6 @@ Synopsis
 --------
 - The command module allows running one or more commands on remote devices running VyOS.  This module can also be introspected to validate key parameters before returning successfully.  If the conditional statements are not met in the wait period, the task fails.
 - Certain ``show`` commands in VyOS produce many lines of output and use a custom pager that can cause this module to hang.  If the value of the environment variable ``ANSIBLE_VYOS_TERMINAL_LENGTH`` is not set, the default number of 10000 is used.
-- EdgeOS, a fork of Vyatta used on Ubiquity devices, uses a different command to set the terminal configuration.  If the value of the environment variable ``ANSIBLE_VYOS_TERMINAL_CONFIG_COMMAND`` is not set, the default command `set terminal` is used.  To work on EdgeOS, you need to set it to just `terminal`.
 
 
 

--- a/docs/vyos.vyos.vyos_command_module.rst
+++ b/docs/vyos.vyos.vyos_command_module.rst
@@ -19,6 +19,7 @@ Synopsis
 --------
 - The command module allows running one or more commands on remote devices running VyOS.  This module can also be introspected to validate key parameters before returning successfully.  If the conditional statements are not met in the wait period, the task fails.
 - Certain ``show`` commands in VyOS produce many lines of output and use a custom pager that can cause this module to hang.  If the value of the environment variable ``ANSIBLE_VYOS_TERMINAL_LENGTH`` is not set, the default number of 10000 is used.
+- EdgeOS, a fork of Vyatta used on Ubiquity devices, uses a different command to set the terminal configuration.  If the value of the environment variable ``ANSIBLE_VYOS_TERMINAL_CONFIG_COMMAND`` is not set, the default command `set terminal` is used.  To work on EdgeOS, you need to set it to just `terminal`.
 
 
 


### PR DESCRIPTION
##### SUMMARY
This allows one to override the default "set terminal" prefix.  On edgeos, a ubiquity fork or something of vyos/vyatta, you need to use "terminal xxxx xxxx" and not "set terminal xxxx xxxx".  This allows an override using an environment variable called `ANSIBLE_VYOS_TERMINAL_CONFIG_COMMAND`.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
vyos terminal plugin

##### ADDITIONAL INFORMATION
Run anything that outputs a fair amount of lines on a edgeos flavor of vyos, like an edgerouter x.  An example would be vyos_"show configuration" or using the `vyos_config:\n  backup:`.  The first one works, as it outputs a low amount of lines, the next three fail due to presenting the output with a pager:

```
❯ cat roles/ansible_vyos_router/tasks/main.yaml                                                        [11:43:31]
---
  - name: vyos version
    vyos.vyos.vyos_command:
      commands: show version

  - name: vyos version
    vyos.vyos.vyos_command:
      commands: show configuration

  - name: Gather facts
    vyos.vyos.vyos_facts:
      gather_subset: all
 
  - name: config
    vyos.vyos.vyos_config:
      backup: yes
      backup_options:
        filename: backup.cfg
        dir_path: /home/randall/
    vars:
      ansible_command_timeout: 60
```

Before:

```paste below
TASK [ansible_vyos_router : config] ******************************************************************************
task path: /home/randall/code/icx/ansible/roles/ansible_vyos_router/tasks/main.yaml:14
Loading collection ansible.netcommon from /home/randall/.ansible/collections/ansible_collections/ansible/netcommon
<192.168.128.1> attempting to start connection
<192.168.128.1> using connection plugin ansible.netcommon.network_cli
Found ansible-connection at path /usr/bin/ansible-connection
<192.168.128.1> found existing local domain socket, using it!
<192.168.128.1> Response received, triggered 'persistent_buffer_read_timeout' timer of 0.1 seconds
<192.168.128.1> updating play_context for connection
<192.168.128.1>
<192.168.128.1> local domain socket path is /home/randall/.ansible/pc/a638b185e8
<192.168.128.1> Using network group action vyos.vyos.vyos for vyos.vyos.vyos_config
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: enabled
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: found vyos.vyos.vyos_config  at /home/randall/.ansible/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_config.py
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: running vyos.vyos.vyos_config
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: complete
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: Result: {'failed': True, 'msg': 'command timeout triggered, timeout value is 60 secs.\nSee the timeout setting options in the Network Debug and Troubleshooting Guide.', 'exception': '  File "/home/randall/.ansible/collections/ansible_collections/vyos/vyos/plugins/module_utils/network/vyos/vyos.py", line 101, in get_config\n    out = connection.get_config(flags=flags, format=format)\n  File "/usr/lib/python3/dist-packages/ansible/module_utils/connection.py", line 200, in __rpc__\n    raise ConnectionError(to_text(msg, errors=\'surrogate_then_replace\'), code=code)\n', 'invocation': {'module_args': {'backup': True, 'backup_options': {'filename': 'backup.cfg', 'dir_path': '/home/randall/'}, 'match': 'line', 'comment': 'configured by vyos_config', 'save': False, 'src': None, 'lines': None, 'config': None, 'provider': None}}, '_ansible_parsed': True}
The full traceback is:
  File "/home/randall/.ansible/collections/ansible_collections/vyos/vyos/plugins/module_utils/network/vyos/vyos.py", line 101, in get_config
    out = connection.get_config(flags=flags, format=format)
  File "/usr/lib/python3/dist-packages/ansible/module_utils/connection.py", line 200, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
fatal: [purveyput]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "backup": true,
            "backup_options": {
                "dir_path": "/home/randall/",
                "filename": "backup.cfg"
            },
            "comment": "configured by vyos_config",
            "config": null,
            "lines": null,
            "match": "line",
            "provider": null,
            "save": false,
            "src": null
        }
    },
    "msg": "command timeout triggered, timeout value is 60 secs.\nSee the timeout setting options in the Network Debug and Troubleshooting Guide."
}
```

After:

```
TASK [ansible_vyos_router : config] ******************************************************************************
task path: /home/randall/code/icx/ansible/roles/ansible_vyos_router/tasks/main.yaml:14
Loading collection ansible.netcommon from /home/randall/.ansible/collections/ansible_collections/ansible/netcommon
<192.168.128.1> attempting to start connection
<192.168.128.1> using connection plugin ansible.netcommon.network_cli
Found ansible-connection at path /usr/bin/ansible-connection
<192.168.128.1> found existing local domain socket, using it!
<192.168.128.1> Response received, triggered 'persistent_buffer_read_timeout' timer of 0.1 seconds
<192.168.128.1> updating play_context for connection
<192.168.128.1>
<192.168.128.1> local domain socket path is /home/randall/.ansible/pc/da26856d83
<192.168.128.1> Using network group action vyos.vyos.vyos for vyos.vyos.vyos_config
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: enabled
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: found vyos.vyos.vyos_config  at /home/randall/.ansible/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_config.py
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: running vyos.vyos.vyos_config
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: complete
<192.168.128.1> ANSIBLE_NETWORK_IMPORT_MODULES: Result: {'changed': False, '__backup__': "<CONFIG_SNIPPED>", 'invocation': {'module_args': {'backup': True, 'backup_options': {'filename': 'backup.cfg', 'dir_path': '/home/randall/'}, 'match': 'line', 'comment': 'configured by vyos_config', 'save': False, 'src': None, 'lines': None, 'config': None, 'provider': None}}, '_ansible_parsed': True}
ok: [purveyput] => {
    "backup_path": "/home/randall/backup.cfg",
    "changed": false,
    "date": "2022-09-25",
    "invocation": {
        "module_args": {
            "backup": true,
            "backup_options": {
                "dir_path": "/home/randall/",
                "filename": "backup.cfg"
            },
            "comment": "configured by vyos_config",
            "config": null,
            "lines": null,
            "match": "line",
            "provider": null,
            "save": false,
            "src": null
        }
    },
    "time": "11:06:40"
}

```
