### PR TITLE
BGP Password fix

### DIFF
--- a/changelogs/fragments/bgp-password-fix.yml
+++ b/changelogs/fragments/bgp-password-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - bgp_global - changed to use `neighbor.password` rather than `neighbor.address` (https://github.com/ansible-collections/vyos.vyos/issues/304).

--- a/plugins/module_utils/network/vyos/rm_templates/bgp_global.py
+++ b/plugins/module_utils/network/vyos/rm_templates/bgp_global.py
@@ -873,7 +873,7 @@ class Bgp_globalTemplate(NetworkTemplate):
                 *$""",
                 re.VERBOSE,
             ),
-            "setval": "protocols bgp {{ as_number }} neighbor {{ neighbor.address }} password {{ neighbor.address }}",
+            "setval": "protocols bgp {{ as_number }} neighbor {{ neighbor.address }} password {{ neighbor.password }}",
             "compval": "neighbor.password",
             "result": {
                 "as_number": "{{ as_num }}",


### PR DESCRIPTION
Updated command to use neighbor.password rather than neighbor.address

##### SUMMARY
Fixes #304 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bgp_global

