### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+## Project purpose
+The official Ansible Collection for managing VyOS network appliances (`vyos.vyos` namespace). Provides modules, plugins, action handlers, terminal plugins, and resource modules for BGP, OSPF, firewall, interfaces, NTP, etc.
+
+## Tech stack
+- Ansible Collection (Galaxy). Python control-plane code under `plugins/`.
+- `galaxy.yml` declares `namespace: vyos`, `name: vyos`, `version: 6.0.0`, dep `ansible.netcommon >= 2.5.1`, license_file `LICENSE` (GPL-3.0).
+- Test stack: `pytest` + `tox-ansible.ini`; lint via flake8, isort, black (line-length 100), pre-commit, ansible-lint.
+- Runtime deps: `paramiko`, `scp` (`requirements.txt`); `bindep.txt` for system deps.
+
+## Build / test / run
+- Build: `ansible-galaxy collection build` produces a `vyos-vyos-<version>.tar.gz`.
+- Install local dev: `ansible-galaxy collection install . --force`.
+- Test: `tox -e <env>` (see `tox-ansible.ini`); run sanity / unit / integration tests against VyOS 1.3.8 / 1.4.1 / 1.5-rolling.
+
+## Repository layout
+- `plugins/{action,cliconf,doc_fragments,filter,inventory,module_utils,modules,terminal}/` — collection content.
+- `tests/` — sanity, unit, integration; CI under `.github/workflows/tests.yml`.
+- `docs/` — generated module docs.
+- `meta/`, `changelogs/`, `CHANGELOG.rst` — Galaxy + release metadata.
+- `pyproject.toml` (black/pytest config), `.flake8`, `.isort.cfg`, `.ansible-lint`, `.pre-commit-config.yaml`.
+- `.github/workflows/` — `tests.yml`, `release.yml`, `codecoverage.yml`, `cla-check.yml`, `ah_token_refresh.yml`, `check_label.yaml`.
+
+## Cross-repo context
+- Consumed by Ansible users running playbooks against VyOS routers built by `vyos/vyos-build`.
+- Sibling of `VyOS-Networks/vyos-ansible-collection` (older, mostly stale) and `VyOS-Networks/vyos-ansible-smoketests` (Jinja2 playbook smoketests driving this collection).
+- The `vyos.vyos` collection talks to VyOS via `network_cli` connections; supports the same train branches (`current`, `circinus`, `sagitta`, `equuleus`).
+
+## Conventions
+- Commit / PR title: `component: T12345: description` (Phorge ID at https://vyos.dev mandatory).
+- Default branch `main` (not `current` — this repo predates the rename convention).
+- Issues tracked at https://vyos.dev (see `galaxy.yml`).
+- Codecov + CodeRabbit configured (`codecov.yml`, `.coderabbit.yaml`).
+
+## Mirror relationship
+Twin at `VyOS-Networks/vyos.vyos`. Canonical side here.
+
+## Notes for future contributors
+- Galaxy versioning is independent of VyOS train versioning — bump in `galaxy.yml` per release.
+- Tested matrix is in README; expand only after smoketesting against real images.
+- `PR408_README.md` plus `pr408-diagram.png` document a non-trivial historical refactor; read before touching resource-module structure.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos.vyos`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889753). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ The official Ansible Collection for managing VyOS network appliances (`vyos.vyos
 - The `vyos.vyos` collection talks to VyOS via `network_cli` connections; supports the same train branches (`current`, `circinus`, `sagitta`, `equuleus`).
 
 ## Conventions
-- Commit / PR title: `component: T12345: description` (Phorge ID at https://vyos.dev mandatory).
+- Commit / PR title: `T12345: description` (Phorge ID at https://vyos.dev mandatory).
+- Every PR must include exactly one changelog fragment under `changelogs/fragments/`; use `doc_changes` for documentation-only updates, or `trivial` for tooling / housekeeping changes.
 - Default branch `main` (not `current` — this repo predates the rename convention).
 - Issues tracked at https://vyos.dev (see `galaxy.yml`).
 - Codecov + CodeRabbit configured (`codecov.yml`, `.coderabbit.yaml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,3 @@ Twin at `VyOS-Networks/vyos.vyos`. Canonical side here.
 - Galaxy versioning is independent of VyOS train versioning — bump in `galaxy.yml` per release.
 - Tested matrix is in README; expand only after smoketesting against real images.
 - `PR408_README.md` plus `pr408-diagram.png` document a non-trivial historical refactor; read before touching resource-module structure.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos.vyos`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/817889753). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ The official Ansible Collection for managing VyOS network appliances (`vyos.vyos
 ## Build / test / run
 - Build: `ansible-galaxy collection build` produces a `vyos-vyos-<version>.tar.gz`.
 - Install local dev: `ansible-galaxy collection install . --force`.
-- Test: `tox -e <env>` (see `tox-ansible.ini`); run sanity / unit / integration tests against VyOS 1.3.8 / 1.4.1 / 1.5-rolling.
+- Test (unit): `source .venv/bin/activate && PYTHONPATH=".collections" python -m pytest tests/unit` (config in `pyproject.toml`). CI runs sanity / unit / integration via GitHub Actions (`.github/workflows/tests.yml`) against VyOS 1.3.8 / 1.4.1 / 1.5-rolling.
 
 ## Repository layout
 - `plugins/{action,cliconf,doc_fragments,filter,inventory,module_utils,modules,terminal}/` — collection content.
-- `tests/` — sanity, unit, integration; CI under `.github/workflows/tests.yml`.
+- `tests/` — sanity, unit, integration; CI via GitHub Actions under `.github/workflows/tests.yml`.
 - `docs/` — generated module docs.
 - `meta/`, `changelogs/`, `CHANGELOG.rst` — Galaxy + release metadata.
 - `pyproject.toml` (black/pytest config), `.flake8`, `.isort.cfg`, `.ansible-lint`, `.pre-commit-config.yaml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,6 @@ The official Ansible Collection for managing VyOS network appliances (`vyos.vyos
 
 ## Cross-repo context
 - Consumed by Ansible users running playbooks against VyOS routers built by `vyos/vyos-build`.
-- Sibling of `VyOS-Networks/vyos-ansible-smoketests` (Jinja2 playbook smoketests driving this collection).
 - The `vyos.vyos` collection talks to VyOS via `network_cli` connections; supports the same train branches (`current`, `circinus`, `sagitta`, `equuleus`).
 
 ## Conventions
@@ -33,9 +32,6 @@ The official Ansible Collection for managing VyOS network appliances (`vyos.vyos
 - Default branch `main` (not `current` — this repo predates the rename convention).
 - Issues tracked at https://vyos.dev (see `galaxy.yml`).
 - Codecov + CodeRabbit configured (`codecov.yml`, `.coderabbit.yaml`).
-
-## Mirror relationship
-Twin at `VyOS-Networks/vyos.vyos`. Canonical side here.
 
 ## Notes for future contributors
 - Galaxy versioning is independent of VyOS train versioning — bump in `galaxy.yml` per release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ The official Ansible Collection for managing VyOS network appliances (`vyos.vyos
 
 ## Cross-repo context
 - Consumed by Ansible users running playbooks against VyOS routers built by `vyos/vyos-build`.
-- Sibling of `VyOS-Networks/vyos-ansible-collection` (older, mostly stale) and `VyOS-Networks/vyos-ansible-smoketests` (Jinja2 playbook smoketests driving this collection).
+- Sibling of `VyOS-Networks/vyos-ansible-smoketests` (Jinja2 playbook smoketests driving this collection).
 - The `vyos.vyos` collection talks to VyOS via `network_cli` connections; supports the same train branches (`current`, `circinus`, `sagitta`, `equuleus`).
 
 ## Conventions

--- a/changelogs/fragments/T8595-claude-md.yml
+++ b/changelogs/fragments/T8595-claude-md.yml
@@ -1,0 +1,3 @@
+trivial:
+  - Add CLAUDE.md with project purpose, tech stack, build/test/run instructions,
+    repository layout, cross-repo context, conventions, and contributor notes.

--- a/changelogs/fragments/T8595-claude-md.yml
+++ b/changelogs/fragments/T8595-claude-md.yml
@@ -1,3 +1,3 @@
-trivial:
+doc_changes:
   - Add CLAUDE.md with project purpose, tech stack, build/test/run instructions,
     repository layout, cross-repo context, conventions, and contributor notes.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation covering collection scope, metadata, supported VyOS versions, build/test/run instructions, repository layout, cross-repo context, and contribution conventions.
  * Added a changelog fragment recording the new documentation and contributor guidance.
  * Updated agent/instruction registry and cursor rules to reference the new documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
