### PR TITLE
T2295: vyos_user: quote plaintext-password in generated set commands

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -7,6 +7,10 @@ on: # yamllint disable-line rule:truthy
   push:
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   codecoverage:
     env:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -7,10 +7,6 @@ on: # yamllint disable-line rule:truthy
   push:
   pull_request:
     branches: [main]
-
-permissions:
-  contents: read
-
 jobs:
   codecoverage:
     env:

--- a/changelogs/fragments/vyos-user-quote-plaintext-password.yml
+++ b/changelogs/fragments/vyos-user-quote-plaintext-password.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - vyos_user - Quote and escape plaintext-password values in generated set commands so special characters (including embedded single quotes) are accepted by VyOS.
+  - vyos_user - Quote and escape plaintext-password values in set commands so VyOS accepts special characters and embedded single quotes.

--- a/changelogs/fragments/vyos-user-quote-plaintext-password.yml
+++ b/changelogs/fragments/vyos-user-quote-plaintext-password.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vyos_user - Quote plaintext-password values in generated set commands so special characters are accepted by VyOS.

--- a/changelogs/fragments/vyos-user-quote-plaintext-password.yml
+++ b/changelogs/fragments/vyos-user-quote-plaintext-password.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - vyos_user - Quote plaintext-password values in generated set commands so special characters are accepted by VyOS.
+  - vyos_user - Quote and escape plaintext-password values in generated set commands so special characters (including embedded single quotes) are accepted by VyOS.

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -201,7 +201,7 @@ commands:
   returned: always
   type: list
   sample:
-    - set system login user authentication plaintext-password password
+    - set system login user ansible authentication plaintext-password password
 """
 
 import re
@@ -222,6 +222,7 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import
 
 
 def spec_to_commands(updates, module):
+    """Generate VyOS CLI commands from a list of (want, have) update tuples."""
     commands = list()
     update_password = module.params["update_password"]
 
@@ -285,6 +286,7 @@ def spec_to_commands(updates, module):
 
 
 def parse_full_name(data):
+    """Extract the full-name value from a VyOS user configuration block."""
     match = re.search(r"full-name '(\S+)'", data, re.M)
     if match:
         full_name = match.group(1)[1:-1]
@@ -292,6 +294,7 @@ def parse_full_name(data):
 
 
 def parse_key(data):
+    """Extract the public key string from an SSH key configuration block."""
     match = re.search(r"key '(\S+)'", data, re.M)
     if match:
         key = match.group(1)
@@ -299,6 +302,7 @@ def parse_key(data):
 
 
 def parse_key_type(data):
+    """Extract the key type from an SSH key configuration block."""
     match = re.search(r"type '(\S+)'", data, re.M)
     if match:
         key_type = match.group(1)
@@ -329,6 +333,7 @@ def parse_public_keys(data):
 
 
 def parse_encrypted_password(data):
+    """Extract the encrypted password from a VyOS user configuration block."""
     match = re.search(r"authentication encrypted-password '(\S+)'", data, re.M)
     if match:
         encrypted_password = match.group(1)
@@ -336,6 +341,7 @@ def parse_encrypted_password(data):
 
 
 def config_to_dict(module):
+    """Read the running configuration and return a list of current user objects."""
     data = get_config(module)
 
     match = re.findall(r"^set system login user (\S+)", data, re.M)
@@ -362,6 +368,7 @@ def config_to_dict(module):
 
 
 def get_param_value(key, item, module):
+    """Return the effective value for a parameter, falling back to module params and running any validator."""
     # if key doesn't exist in the item, get it from module.params
     if not item.get(key):
         value = module.params[key]
@@ -392,6 +399,7 @@ def map_key_params_to_dict(keys):
 
 
 def map_params_to_obj(module):
+    """Build a list of normalised user objects from module parameters."""
     aggregate = module.params["aggregate"]
     if not aggregate:
         if not module.params["name"] and module.params["purge"]:
@@ -421,6 +429,7 @@ def map_params_to_obj(module):
 
 
 def update_objects(want, have):
+    """Compare desired state against current state and return pairs that require changes."""
     updates = list()
     for entry in want:
         item = next((i for i in have if i["name"] == entry["name"]), None)

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -276,7 +276,7 @@ def spec_to_commands(updates, module):
                 add(
                     commands,
                     want,
-                    "authentication plaintext-password %s" % want["configured_password"],
+                    "authentication plaintext-password '%s'" % want["configured_password"],
                 )
 
     return commands

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -201,7 +201,7 @@ commands:
   returned: always
   type: list
   sample:
-    - set system login user ansible authentication plaintext-password password
+    - set system login user authentication plaintext-password password
 """
 
 import re
@@ -222,7 +222,6 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import
 
 
 def spec_to_commands(updates, module):
-    """Generate VyOS CLI commands from a list of (want, have) update tuples."""
     commands = list()
     update_password = module.params["update_password"]
 
@@ -286,7 +285,6 @@ def spec_to_commands(updates, module):
 
 
 def parse_full_name(data):
-    """Extract the full-name value from a VyOS user configuration block."""
     match = re.search(r"full-name '(\S+)'", data, re.M)
     if match:
         full_name = match.group(1)[1:-1]
@@ -294,7 +292,6 @@ def parse_full_name(data):
 
 
 def parse_key(data):
-    """Extract the public key string from an SSH key configuration block."""
     match = re.search(r"key '(\S+)'", data, re.M)
     if match:
         key = match.group(1)
@@ -302,7 +299,6 @@ def parse_key(data):
 
 
 def parse_key_type(data):
-    """Extract the key type from an SSH key configuration block."""
     match = re.search(r"type '(\S+)'", data, re.M)
     if match:
         key_type = match.group(1)
@@ -333,7 +329,6 @@ def parse_public_keys(data):
 
 
 def parse_encrypted_password(data):
-    """Extract the encrypted password from a VyOS user configuration block."""
     match = re.search(r"authentication encrypted-password '(\S+)'", data, re.M)
     if match:
         encrypted_password = match.group(1)
@@ -341,7 +336,6 @@ def parse_encrypted_password(data):
 
 
 def config_to_dict(module):
-    """Read the running configuration and return a list of current user objects."""
     data = get_config(module)
 
     match = re.findall(r"^set system login user (\S+)", data, re.M)
@@ -368,7 +362,6 @@ def config_to_dict(module):
 
 
 def get_param_value(key, item, module):
-    """Return the effective value for a parameter, falling back to module params and running any validator."""
     # if key doesn't exist in the item, get it from module.params
     if not item.get(key):
         value = module.params[key]
@@ -399,7 +392,6 @@ def map_key_params_to_dict(keys):
 
 
 def map_params_to_obj(module):
-    """Build a list of normalised user objects from module parameters."""
     aggregate = module.params["aggregate"]
     if not aggregate:
         if not module.params["name"] and module.params["purge"]:
@@ -429,7 +421,6 @@ def map_params_to_obj(module):
 
 
 def update_objects(want, have):
-    """Compare desired state against current state and return pairs that require changes."""
     updates = list()
     for entry in want:
         item = next((i for i in have if i["name"] == entry["name"]), None)

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -201,7 +201,7 @@ commands:
   returned: always
   type: list
   sample:
-    - set system login user authentication plaintext-password password
+    - set system login user authentication plaintext-password 'password'
 """
 
 import re
@@ -218,6 +218,11 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import
     get_config,
     load_config,
 )
+
+
+def _quote_config_value(value):
+    """Return a shell-safe quoted value for VyOS set commands."""
+    return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
 def spec_to_commands(updates, module):
@@ -276,7 +281,8 @@ def spec_to_commands(updates, module):
                 add(
                     commands,
                     want,
-                    "authentication plaintext-password '%s'" % want["configured_password"],
+                    "authentication plaintext-password %s"
+                    % _quote_config_value(want["configured_password"]),
                 )
 
     return commands

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -201,10 +201,11 @@ commands:
   returned: always
   type: list
   sample:
-    - set system login user authentication plaintext-password 'password'
+    - set system login user authentication plaintext-password password
 """
 
 import re
+import shlex
 
 from copy import deepcopy
 from functools import partial
@@ -218,11 +219,6 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import
     get_config,
     load_config,
 )
-
-
-def _quote_config_value(value):
-    """Return a shell-safe quoted value for VyOS set commands."""
-    return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
 def spec_to_commands(updates, module):
@@ -282,7 +278,7 @@ def spec_to_commands(updates, module):
                     commands,
                     want,
                     "authentication plaintext-password %s"
-                    % _quote_config_value(want["configured_password"]),
+                    % shlex.quote(want["configured_password"]),
                 )
 
     return commands

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -62,6 +62,26 @@ class TestVyosUserModule(TestVyosModule):
             ["set system login user ansible authentication plaintext-password 'test'"],
         )
 
+    def test_vyos_user_password_special_chars(self):
+        set_module_args(dict(name="ansible", configured_password="test$123!@"))
+        result = self.execute_module(changed=True)
+        self.assertEqual(
+            result["commands"],
+            [
+                "set system login user ansible authentication plaintext-password 'test$123!@'",
+            ],
+        )
+
+    def test_vyos_user_password_embedded_quote(self):
+        set_module_args(dict(name="ansible", configured_password="pa'ss"))
+        result = self.execute_module(changed=True)
+        self.assertEqual(
+            result["commands"],
+            [
+                "set system login user ansible authentication plaintext-password 'pa'\"'\"'ss'",
+            ],
+        )
+
     def test_vyos_user_delete(self):
         set_module_args(dict(name="ansible", state="absent"))
         result = self.execute_module(changed=True)

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import shlex
 from unittest.mock import patch
 
 from ansible_collections.vyos.vyos.plugins.modules import vyos_user
@@ -81,6 +82,16 @@ class TestVyosUserModule(TestVyosModule):
                 "set system login user ansible authentication plaintext-password 'pa'\"'\"'ss'",
             ],
         )
+
+    def test_vyos_user_password_complex_special_chars(self):
+        password = "P@ss w0rd!$#'xy\\"
+        set_module_args(dict(name="ansible", configured_password=password))
+        result = self.execute_module(changed=True)
+        expected_command = (
+            "set system login user ansible authentication plaintext-password %s"
+            % shlex.quote(password)
+        )
+        self.assertEqual(result["commands"], [expected_command])
 
     def test_vyos_user_delete(self):
         set_module_args(dict(name="ansible", state="absent"))

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -59,7 +59,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user ansible authentication plaintext-password test"],
+            ["set system login user ansible authentication plaintext-password 'test'"],
         )
 
     def test_vyos_user_delete(self):
@@ -92,7 +92,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user test authentication plaintext-password test"],
+            ["set system login user test authentication plaintext-password 'test'"],
         )
 
     def test_vyos_user_update_password_on_create_ok(self):
@@ -116,7 +116,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user ansible authentication plaintext-password test"],
+            ["set system login user ansible authentication plaintext-password 'test'"],
         )
 
     def test_vyos_user_set_ssh_key(self):

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -59,7 +59,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user ansible authentication plaintext-password 'test'"],
+            ["set system login user ansible authentication plaintext-password test"],
         )
 
     def test_vyos_user_password_special_chars(self):
@@ -112,7 +112,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user test authentication plaintext-password 'test'"],
+            ["set system login user test authentication plaintext-password test"],
         )
 
     def test_vyos_user_update_password_on_create_ok(self):
@@ -136,7 +136,7 @@ class TestVyosUserModule(TestVyosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(
             result["commands"],
-            ["set system login user ansible authentication plaintext-password 'test'"],
+            ["set system login user ansible authentication plaintext-password test"],
         )
 
     def test_vyos_user_set_ssh_key(self):

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import shlex
 from unittest.mock import patch
 
 from ansible_collections.vyos.vyos.plugins.modules import vyos_user
@@ -84,14 +83,14 @@ class TestVyosUserModule(TestVyosModule):
         )
 
     def test_vyos_user_password_complex_special_chars(self):
-        password = "P@ss w0rd!$#'xy\\"
-        set_module_args(dict(name="ansible", configured_password=password))
+        set_module_args(dict(name="ansible", configured_password="P@ss w0rd!$#'xy\\"))
         result = self.execute_module(changed=True)
-        expected_command = (
-            "set system login user ansible authentication plaintext-password %s"
-            % shlex.quote(password)
+        self.assertEqual(
+            result["commands"],
+            [
+                "set system login user ansible authentication plaintext-password 'P@ss w0rd!$#'\"'\"'xy\\'",
+            ],
         )
-        self.assertEqual(result["commands"], [expected_command])
 
     def test_vyos_user_delete(self):
         set_module_args(dict(name="ansible", state="absent"))


### PR DESCRIPTION
## Summary
- Quote `configured_password` values in `spec_to_commands` so VyOS accepts passwords with special characters (`!`, `$`, spaces, etc.).
- Aligns with how the module already quotes `encrypted_password`, `full_name`, and public keys.
- Updates unit test expectations and adds a changelog fragment.

## Test plan
- [x] `pytest tests/unit/modules/network/vyos/test_vyos_user.py` (14 passed locally)


Made with [Cursor](https://cursor.com)