### PR TITLE
T8966: add legacy-label escape to invalid-task-id rule (commit check exempt)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,11 +6,17 @@ merge_protections_settings:
 pull_request_rules:
   - name: Flag product T-ID format violation in PR title or commit messages
     description: >
-      Product-repo convention: PR title and every commit's first line must
-      match `T<digits>: <text>` (optional `scope: ` prefix). Relocated from
-      the central config (T8966) so the T-ID convention is opt-in per product
-      repo. Name is intentionally distinct from any central rule name so this
-      stays additive (not an `extends:` override).
+      Product-repo convention: the PR title AND every commit's first line must
+      match `T<digits>: <text>` (optional `scope: ` prefix). The title is always
+      checked; the per-commit check is exempted when a maintainer applies the
+      `legacy` label — an escape hatch for grandfathered PRs whose commit history
+      cannot be rewritten (repos that squash-merge AND block force-push, e.g.
+      vyos.vyos enforces `non_fast_forward` on ~ALL branches with zero bypass).
+      New PRs are still nudged toward the convention; `legacy` is the deliberate,
+      maintainer-controlled opt-out. Relocated from the central config (T8966)
+      so the convention is opt-in per product repo. Name is intentionally
+      distinct from any central rule name so this stays additive (not an
+      `extends:` override). Legacy-label escape added 2026-06-08 (T8966).
     conditions:
       - '-closed'
       - '-merged'
@@ -19,7 +25,9 @@ pull_request_rules:
       - 'author!=vyosbot'
       - or:
           - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
-          - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+          - and:
+              - 'label!=legacy'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
     actions:
       label:
         toggle:


### PR DESCRIPTION
## What

Adds a maintainer-controlled `legacy` label escape to the per-repo Mergify rule that toggles `invalid-task-id`. The PR **title** check stays enforced for every PR; the **per-commit** check is exempted when a PR carries the `legacy` label.

```diff
       - or:
           - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'      # title: always checked
-          - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+          - and:
+              - 'label!=legacy'                                       # commits: skipped when legacy
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
```

## Why

A fleet scan found 16 open PRs labeled `invalid-task-id`; 10/16 have a **valid title** and are flagged only on intermediate/merge commit messages. On this repo those labels are **unclearable**: `vyos.vyos` ruleset `15138379` ("Co-Pilot Review") enforces `non_fast_forward` on `~ALL` branches with **zero bypass actors**, so no author (or admin) can rewrite commit history to make existing commits conform — and intermediate/merge commits never reach history under squash-merge anyway.

`legacy` gives maintainers a deliberate, auditable opt-out for grandfathered PRs while preserving title hygiene and continuing to nudge new PRs toward the convention.

## Rollout

Pilot on `vyos.vyos` (12 of 16 labeled PRs live here). After merge: create the `legacy` label, apply it to the 9 valid-title PRs, and confirm Mergify's `label.toggle` clears `invalid-task-id`. Then fan out the rule change to the remaining ~51 product repos.

Change-management: [IS-539](https://vyos.atlassian.net/browse/IS-539) · Tracked under T8966.

🤖 Generated by [robots](https://vyos.io)


[IS-539]: https://vyos.atlassian.net/browse/IS-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ