### PR TITLE
ci: T9082: onboard CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: "Perform CodeQL Analysis"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!**/*.md'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!**/*.md'
+  schedule:
+    - cron: '52 13 * * 0'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql-analysis-call:
+    uses: vyos/.github/.github/workflows/codeql-analysis.yml@production
+    with:
+      languages: "['python']"

--- a/changelogs/fragments/T9082-codeql-workflow.yml
+++ b/changelogs/fragments/T9082-codeql-workflow.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Add CodeQL analysis workflow calling the VyOS org-wide central reusable (T9082).


### PR DESCRIPTION
Adds a thin caller of the central CodeQL reusable workflow ([vyos/.github](https://github.com/vyos/.github) `codeql-analysis.yml`) — push/PR on `main` + weekly cron. Advisory only; not a required check.

Part of the vyos-org CodeQL rollout ([T9082](https://vyos.dev/T9082), [IS-610](https://vyos.atlassian.net/browse/IS-610)). Reusable + caller shape pre-validated on the T9082 canaries (ipaddrcheck: legacy autobuild on v4, validation fail-fast, build-mode none + coverage parity; rest.vyos: legacy interpreted row).

Advances: IS-610

🤖 Generated by [robots](https://vyos.io)

[IS-610]: https://vyos.atlassian.net/browse/IS-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ